### PR TITLE
Replacing all the instances of IoFreeMdl with UnlockAndFreeMDL routin…

### DIFF
--- a/ZFSin/zfs/module/zfs/vdev_disk.c
+++ b/ZFSin/zfs/module/zfs/vdev_disk.c
@@ -44,6 +44,8 @@
 
 static void vdev_disk_close(vdev_t *);
 
+extern void UnlockAndFreeMdl(PMDL);
+
 static void
 vdev_disk_alloc(vdev_t *vd)
 {
@@ -410,16 +412,7 @@ vdev_disk_io_intrxxx(PDEVICE_OBJECT DeviceObject, PIRP irp, PVOID Context)
 {
 	KeSetEvent((KEVENT *)Context, NT_SUCCESS(irp->IoStatus.Status) ? IO_DISK_INCREMENT : IO_NO_INCREMENT, FALSE);
 	// zfs/zfs-15
-	PMDL currentMdl, nextMdl;
-	for (currentMdl = irp->MdlAddress; currentMdl != NULL; currentMdl = nextMdl)
-	{
-		nextMdl = currentMdl->Next;
-		if (currentMdl->MdlFlags & MDL_PAGES_LOCKED)
-		{
-			MmUnlockPages(currentMdl);
-		}
-		IoFreeMdl(currentMdl);
-	}
+	UnlockAndFreeMdl(irp->MdlAddress);
 	IoFreeIrp(irp);
 	return STATUS_MORE_PROCESSING_REQUIRED;
 }

--- a/ZFSin/zfs/module/zfs/vdev_file.c
+++ b/ZFSin/zfs/module/zfs/vdev_file.c
@@ -40,6 +40,8 @@
 
 static taskq_t *vdev_file_taskq;
 
+extern void UnlockAndFreeMdl(PMDL);
+
 static void
 vdev_file_hold(vdev_t *vd)
 {
@@ -331,16 +333,7 @@ vdev_file_io_intrxxx(PDEVICE_OBJECT DeviceObject, PIRP irp, PVOID Context)
 {
 	KeSetEvent((KEVENT*)Context, NT_SUCCESS(irp->IoStatus.Status) ? IO_DISK_INCREMENT : IO_NO_INCREMENT, FALSE);
 	// zfs/zfs-15
-	PMDL currentMdl, nextMdl;
-	for (currentMdl = irp->MdlAddress; currentMdl != NULL; currentMdl = nextMdl)
-	{
-		nextMdl = currentMdl->Next;
-		if (currentMdl->MdlFlags & MDL_PAGES_LOCKED)
-		{
-			MmUnlockPages(currentMdl);
-		}
-		IoFreeMdl(currentMdl);
-	}
+	UnlockAndFreeMdl(irp->MdlAddress);
 	IoFreeIrp(irp);
 	return STATUS_MORE_PROCESSING_REQUIRED;
 }

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -119,6 +119,8 @@ uint64_t vnop_num_vnodes = 0;
 uint64_t zfs_disable_wincache = 0;
 #endif
 
+extern void UnlockAndFreeMdl(PMDL );
+
 BOOLEAN zfs_AcquireForLazyWrite(void *Context, BOOLEAN Wait)
 {
 	struct vnode *vp = Context;
@@ -3769,8 +3771,7 @@ void zfsdev_async_thread(void *arg)
 
 	PMDL mdl = Irp->Tail.Overlay.DriverContext[0];
 	if (mdl) {
-		MmUnlockPages(mdl);
-		IoFreeMdl(mdl);
+		UnlockAndFreeMdl(mdl);
 		Irp->Tail.Overlay.DriverContext[0] = NULL;
 	}
 	void *fp = Irp->Tail.Overlay.DriverContext[1];
@@ -3830,8 +3831,7 @@ NTSTATUS zfsdev_async(PDEVICE_OBJECT DeviceObject, PIRP Irp)
 	return STATUS_PENDING;
 out:	
 	if (mdl) {
-		MmUnlockPages(mdl);
-		IoFreeMdl(mdl);
+		UnlockAndFreeMdl(mdl);
 	}
 	if (fp) {
 		ObDereferenceObject(fp);


### PR DESCRIPTION
…e (#227)

* Fix for MDL related memory leaks

* Refactor vdev_file.c and vdev_disk.c to leverage UnlockAndFreeMDL function

* Replacing all the instances of IoFreeMdl with UnlockAndFreeMDL routine