### PR TITLE
Use ULONGLONG for sectorOffset instead of ULONG.

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -701,9 +701,8 @@ wzvol_WkRtn(__in PVOID pWkParms)                          // Parm list pointer.
 	PSCSI_REQUEST_BLOCK       pSrb = pWkRtnParms->pSrb;
 	PCDB                      pCdb = (PCDB)pSrb->Cdb;
 	PHW_SRB_EXTENSION         pSrbExt = (PHW_SRB_EXTENSION)pSrb->SrbExtension;
-	ULONG                     startingSector,
-		sectorOffset,
-		lclStatus;
+	ULONGLONG                 startingSector, sectorOffset;
+	ULONG                     lclStatus;
 	PVOID                     pX = NULL;
 	UCHAR                     status;
 


### PR DESCRIPTION
sectorOffset can go beyond 32 bits for a large ZVOL. 