### PR TITLE
  Changed spl_hostid datatype from uint8_t to uint32_t, which was cau…

### DIFF
--- a/ZFSin/spl/module/spl/spl-windows.c
+++ b/ZFSin/spl/module/spl/spl-windows.c
@@ -76,7 +76,7 @@ extern uint64_t		segkmem_total_mem_allocated;
 #define MAXHOSTNAMELEN 64
 extern char hostname[MAXHOSTNAMELEN];
 
-uint8_t spl_hostid = 0;
+uint32_t spl_hostid = 0;
 
 /*
  * Solaris delay is in ticks (hz) and Windows in 100 nanosecs


### PR DESCRIPTION
Changed spl_hostid datatype from uint8_t to uint32_t, which was causing hostid mismatch during zpool import.
