### PR TITLE
Fixed wrong assertion in libspl

### DIFF
--- a/ZFSin/zfs/lib/libspl/posix.c
+++ b/ZFSin/zfs/lib/libspl/posix.c
@@ -545,8 +545,9 @@ unsigned long gethostid(void)
 	Status = RegQueryValueEx(key, "hostid", NULL, &type, (LPBYTE)&hostid, &len);
 	if (Status != ERROR_SUCCESS)
 		hostid = 0;
-
-	assert(type == REG_DWORD);
+	else {
+		assert(type == REG_DWORD);
+	}
 
 	RegCloseKey(key);
 


### PR DESCRIPTION
problem: When the hostid value is not yet defined in the registry the library throws an assertion sometimes while trying to import the pool.

reason: the value type is not initialized in the stack so when the registry call fails to get the hostid the type value is still compared to REG_DWORD.

fix: do not check for possible assertion on the value type if the call failed.