### PR TITLE
zfs-207 - ensure completion routine call during DI failures

### DIFF
--- a/ZFSin/zfs/lib/libspl/posix.c
+++ b/ZFSin/zfs/lib/libspl/posix.c
@@ -545,8 +545,9 @@ unsigned long gethostid(void)
 	Status = RegQueryValueEx(key, "hostid", NULL, &type, (LPBYTE)&hostid, &len);
 	if (Status != ERROR_SUCCESS)
 		hostid = 0;
-
-	assert(type == REG_DWORD);
+	else {
+		assert(type == REG_DWORD);
+	}
 
 	RegCloseKey(key);
 

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -945,6 +945,10 @@ DiReadWriteSetup(
 		ActionRead == action ? UIO_READ : UIO_WRITE);
 	if (uio == NULL) {
 		dprintf("%s: out of memory.\n", __func__);
+		// ZFS-207: a failure prior to queueing the request must call the caller's IRP completion routine, if any set.
+		if (pIo->Cb) {
+			pIo->Cb(pIo, STATUS_INSUFFICIENT_RESOURCES, FALSE);
+		}
 		return STATUS_INSUFFICIENT_RESOURCES;
 	}
 	VERIFY0(uio_addiov(uio, (user_addr_t)pIo->Buffer,


### PR DESCRIPTION
problem: It was possible for a DI request to be failed before being queued up for processing in the ZFS driver. when this happened the pool driver would never get its IRP completion routine called.

fix: if the I/O processing is failed in ZFS prior to queuing to the I/O, added the call for the DI callback to run.
Once the I/O is processed by the queuing mechanism it will always call the DI callback.