### PR TITLE
Logman Session creation and deletion

### DIFF
--- a/ZFSin.sln
+++ b/ZFSin.sln
@@ -70,6 +70,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kstat", "ZFSin\zfs\cmd\kstat\kstat.vcxproj", "{124252BB-55ED-429B-AF4B-9D19043912D1}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zfsinstaller", "zfsinstaller\zfsinstaller.vcxproj", "{D8FFC7E2-16B5-4A68-86BD-C570669EA263}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5514A992-229B-47B4-9E37-8299A4C1263A} = {5514A992-229B-47B4-9E37-8299A4C1263A}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/zfsinstaller/zfsinstaller.cpp
+++ b/zfsinstaller/zfsinstaller.cpp
@@ -23,46 +23,294 @@
   */
 
 #include "zfsinstaller.h"
+#include <ctime>
+#include <string>
 
-// Usage:
-//	zfsinstaller install [inf] [installFolder] (defaults to something like %ProgramFiles%\ZFS)
-//	zfsinstaller uninstall [inf] (could default to something like %ProgramFiles%\ZFS\ZFSin.inf)
-//
-//
+extern "C" {
+	#include <getopt.h>
+	extern char* optarg;
+	extern int optind;
+}
+
+#define MAX_PATH_LEN 1024
+
+//  Usage:
+//    zfsinstaller install [inf] [installFolder] (defaults to something like %ProgramFiles%\ZFS)
+//    zfsinstaller uninstall [inf] (could default to something like %ProgramFiles%\ZFS\ZFSin.inf)
+//    zfsinstaller trace [-f Flags] [-l Levels] [-s SizeOfETLInMB] [-p AbsolutePathOfETL]
+//    zfsinstaller trace -d
+
+const unsigned char ZFSIN_GUID[] = "c20c603c-afd4-467d-bf76-c0a4c10553df";
+const unsigned char LOGGER_SESSION[] = "autosession\\zfsin_trace";
+const std::string ETL_FILE("\\ZFSin.etl");
+
+int session_exists(void)
+{
+	char   command[MAX_PATH_LEN];
+
+	sprintf_s(command, "logman query %s > nul", LOGGER_SESSION);
+
+	return system(command);  // returns 0 if Session exists else non-zero if Session does not exist
+}
+
+int zfs_log_session_delete(void)
+{
+	char command[MAX_PATH_LEN];
+
+	int ret = session_exists();
+
+	if (ret == 0) {  // Session exists
+		sprintf_s(command, "logman delete %s > nul", LOGGER_SESSION);
+		ret = system(command);
+		if (ret == 0)
+			fprintf(stderr, "Logman session %s deleted successfully\n", LOGGER_SESSION);
+		else
+			fprintf(stderr, "Error while deleting session %s\n", LOGGER_SESSION);
+		return ret;
+	} else
+		return 0; // Session does not exist ; We will pass success
+}
+
+int validate_flag_level(const char* str, size_t len)
+{
+	if ((str[0] == '0') && (str[1] == 'x' || str[1] == 'X')) str += 2;
+
+	while (*str == '0') ++str;
+
+	size_t length = strlen(str);
+	if (length > len)
+		return 1;
+	if (*str == '-')
+		return 2;
+	if (str[strspn(str, "0123456789abcdefABCDEF")] == 0)
+		return 0;   // Vaild hex string;
+	else
+		return 3;   // Invalid hex string;
+}
+
+int validate_args(const char* flags, const char* levels, int size_in_mb, const char* etl_file)
+{
+	if (validate_flag_level(flags, 8)){
+		fprintf(stderr, "Valid input for flags should be in interval [0x0, 0xffffffff]\n");
+		return 1;
+	}
+
+	if(validate_flag_level(levels, 2)) {
+		fprintf(stderr, "Valid input for levels should be in interval [0x0, 0xff]\n");
+		return 2;
+	}
+
+	if (etl_file) {
+		if (!strstr(etl_file, ".etl")) {
+			fprintf(stderr, "Etl file path/name %s is incorrect\n", etl_file);
+			return 3;
+		}
+	} else {
+			fprintf(stderr, "Etl file path/name is incorrect\n");
+			return 4;
+	}
+
+	if (size_in_mb <= 0) {
+		fprintf(stderr, "Size of etl should be greater than 0\n");
+		return 5;
+	}
+	return 0;
+}
+
+int move_file(const char *etl_file)
+{
+	char move_etl[MAX_PATH_LEN];
+	time_t rawtime;
+	struct tm timeinfo;
+	char buffer[25];
+
+	time(&rawtime);
+	localtime_s(&timeinfo, &rawtime);
+	strftime(buffer, sizeof(buffer), "_%Y%m%d%H%M%S", &timeinfo);
+
+	strcpy_s(move_etl, etl_file);
+	char* etl = strstr(move_etl, ".etl");
+	if (etl)
+		etl[0] = 0;
+
+	strcat_s(move_etl, buffer);
+	strcat_s(move_etl, ".etl");
+
+	if (0 == rename(etl_file, move_etl)) {
+		fprintf(stderr, "%s already exists\n", etl_file);
+		fprintf(stderr, "%s has been renamed to %s\n", etl_file, move_etl);
+		return 0;
+	} else {
+		fprintf(stderr, "Error while renaming the file %s\n", etl_file);
+		return 1;
+	}
+}
+
+void hex_modify(std::string& hex)
+{
+	if (hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X'))
+		return;
+	hex = std::string("0x") + hex;
+}
+
+int arg_parser(int argc, char **argv, std::string &flags, std::string &levels, int &size_in_mb, std::string &etl_file)
+{
+	int option_index = 0;
+	while ((option_index = getopt(argc, argv, "l:f:s:p:d")) != -1) {
+		switch (option_index) {
+		case 'p':
+			etl_file = std::string(optarg);
+			break;
+		case 'l':
+			levels = std::string(optarg);
+			hex_modify(levels);
+			break;
+		case 'f':
+			flags = std::string(optarg);
+			hex_modify(flags);
+			break;
+		case 's':
+			size_in_mb = atoi(optarg);
+			break;
+		case 'd':
+			fprintf(stderr, "-d cannot used with other parameters\n");
+			return 1;
+		default:
+			fprintf(stderr, "Incorrect argument provided\n");
+			return ERROR_BAD_ARGUMENTS;
+		}
+	}
+	int index = optind;
+	while (index < argc) {
+		fprintf(stderr, "Non-option argument %s\n", argv[index]);
+		index++;
+	}
+	if (optind < argc)
+		return ERROR_BAD_ARGUMENTS;
+
+	if (0 == flags.size())       flags = std::string("0xffffffff");
+	if (0 == levels.size())      levels = std::string("0x3");
+	if (-1 == size_in_mb)        size_in_mb = 10;
+	if (0 == etl_file.size()) {
+		TCHAR CurrentPath[MAX_PATH_LEN + 1] = L"";
+		DWORD len = GetCurrentDirectory(MAX_PATH_LEN, CurrentPath);
+		int size_needed = WideCharToMultiByte(CP_UTF8, 0, &CurrentPath[0], MAX_PATH_LEN, NULL, 0, NULL, NULL);
+		std::string CwdPath(size_needed, 0);
+		WideCharToMultiByte(CP_UTF8, 0, &CurrentPath[0], MAX_PATH_LEN, &CwdPath[0], size_needed, NULL, NULL);
+		CwdPath.erase(len);
+		etl_file = CwdPath + ETL_FILE;
+	}
+	return 0;
+}
+
+int zfs_log_session_create(int argc, char** argv)
+{
+	std::string flags;
+	std::string levels;
+	int size_in_mb = -1;
+	std::string etl_file;
+	char command[MAX_PATH_LEN];
+	int ret;
+
+	ret = arg_parser(argc, argv, flags, levels, size_in_mb, etl_file);
+	if (ret) {
+		printUsage();
+		return ret;
+	}
+
+	if (validate_args(flags.c_str(), levels.c_str(), size_in_mb, etl_file.c_str())) {
+		fprintf(stderr, "Please check the provided values for the arguments\n");
+		printUsage();
+		return 1;
+	}
+
+	if (0 != session_exists()) { // If Session does not exist
+		if (GetFileAttributesA(etl_file.c_str()) != INVALID_FILE_ATTRIBUTES) { // ETL EXISTS
+			ret = move_file(etl_file.c_str());
+			if (ret)
+				return ret;
+		}
+
+		sprintf_s(command, "logman create trace %s -p {%s} %s %s -nb 10 10 -bs 100 -mode Circular -max %d -o \"%s\" ",
+							LOGGER_SESSION, ZFSIN_GUID, flags.c_str(), levels.c_str(), size_in_mb, etl_file.c_str());
+
+		ret = system(command);
+		if (ret != 0)
+			fprintf(stderr, "There is an issue creating the session %s\n", LOGGER_SESSION);
+		else 
+			fprintf(stderr, "Logman Session %s successfully created\n", LOGGER_SESSION);
+
+		return ret;
+	} else
+		fprintf(stderr, "Logman Session %s already exists\n", LOGGER_SESSION);
+
+	return 0;
+}
 
 
 int main(int argc, char* argv[])
 {
-	if (argc <= 2) {
+	if (argc < 2) {
 		fprintf(stderr, "too few arguments \n");
 		printUsage();
 		return ERROR_BAD_ARGUMENTS;
 	}
-	if (argc > 3) {
+	if (argc > 10) {
 		fprintf(stderr, "too many arguments \n");
 		printUsage();
 		return ERROR_BAD_ARGUMENTS;
 	}
 
 	if (strcmp(argv[1], "install") == 0) {
-		zfs_install(argv[2]);
-		fprintf(stderr, "Installation done.");
-	} else if(strcmp(argv[1], "uninstall") == 0) {
-		zfs_uninstall(argv[2]);
+		if (argc == 3) {
+			zfs_install(argv[2]);
+			fprintf(stderr, "Installation done.");
+		} else {
+			fprintf(stderr, "Incorrect argument usage\n");
+			printUsage();
+			return ERROR_BAD_ARGUMENTS;
+		}
+	} else if (strcmp(argv[1], "uninstall") == 0) {
+		if (argc == 3) {
+			int ret = zfs_uninstall(argv[2]);
+			if (0 == ret)
+				return zfs_log_session_delete();
+			return ret;
+		} else {
+			fprintf(stderr, "Incorrect argument usage\n");
+			printUsage();
+			return ERROR_BAD_ARGUMENTS;
+		}
+	} else if (strcmp(argv[1], "trace") == 0) {
+		if (argc == 3 && strcmp(argv[2], "-d") == 0)
+			return zfs_log_session_delete();
+		else
+			return zfs_log_session_create(argc - 1, &argv[1]);
 	} else {
 		fprintf(stderr, "unknown argument %s\n", argv[1]);
 		printUsage();
 		return ERROR_BAD_ARGUMENTS;
 	}
+	return 0;
 }
 
 void printUsage() {
-	fprintf(stderr, "Usage:\n\n");
+	fprintf(stderr, "\nUsage:\n\n");
 	fprintf(stderr, "Install driver per INF DefaultInstall section:\n");
-	fprintf(stderr, "zfsinstaller install [inf path]\n");
+	fprintf(stderr, "zfsinstaller install inf_path\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Uninstall driver per INF DefaultUninstall section:\n");
-	fprintf(stderr, "zfsinstaller uninstall [inf path]\n");
+	fprintf(stderr, "zfsinstaller uninstall inf_path\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "zfsinstaller trace [-f Flags] | [-l Levels] | [-s SizeOfETLInMB] | [-p AbsolutePathOfETL]\n");
+	fprintf(stderr, "Valid inputs for above arguments are as follows:\n");
+	fprintf(stderr, "Flags (in hex)              Should be in interval [0x0, 0xffffffff]      Default (0xffffffff)\n");
+	fprintf(stderr, "Levels (in hex)             Should be in interval [0x0, 0xff]            Default (0x3)\n");
+	fprintf(stderr, "SizeOfETLInMB (in decimal)  Should be greater than 0                     Default (10)\n");
+	fprintf(stderr, "AbsolutePathOfETL           Absolute Path including the Etl file name    Default ($CWD%s)\n", ETL_FILE.c_str());
+	fprintf(stderr, "\n");
+	fprintf(stderr, "zfsinstaller trace -d\n");
+	fprintf(stderr, "-d                 To delete the logman session\n");
 }
 
 DWORD zfs_install(char *inf_path) {

--- a/zfsinstaller/zfsinstaller.vcxproj
+++ b/zfsinstaller/zfsinstaller.vcxproj
@@ -92,11 +92,12 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)/ZFSin/zfs/lib/libspl/include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Advapi32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\libspl.lib;Advapi32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
@@ -146,6 +147,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)/ZFSin/zfs/lib/libspl/include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -153,7 +155,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
-      <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(SolutionDir)$(Platform)\$(Configuration)\libspl.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This fix provides a new command 'trace' for zfsinstaller.exe to create a logman (auto)session.

Once driver is installed, user can issue the command "zfsinstaller trace [-f Flags] [-l Levels] [-s SizeOfETLInMB] [-p AbsolutePathOfETL]" to create a logman session.
After reboot, the logs get collected in the path (AbsolutePathOfETL).
Also, handled are some scenarios
i)  If the provided Etl (path) exists already (We rename the existing etl and go ahead with provided etl file name)
ii) We will not create logman session if one already exists.

The etl file size is restricted to 'SizeOfETLInMB'. When it exceeds 'SizeOfETLInMB', older logs gets removed so as to maintain the etl size to 'SizeOfETLInMB'

The session gets deleted when the driver is uninstalled or when issued the command (zfsinstaller.exe trace -d)

One important point to note is that logman session creation/deletion requires a reboot.

Utilized getopt function from libspl library for parsing the arguments; Have also changed the order of build process for zfsinstaller project