### PR TITLE
zfs_total_memory_limit registry entry

### DIFF
--- a/ZFSin/spl/module/spl/spl-kmem.c
+++ b/ZFSin/spl/module/spl/spl-kmem.c
@@ -3358,7 +3358,7 @@ kmem_cache_stat(kmem_cache_t *cp, char *name)
 
 // TRUE if we have more than a critical minimum of memory
 // used in arc_memory_throttle; if FALSE, we throttle
-static inline boolean_t
+boolean_t
 spl_minimal_physmem_p_logic()
 {
 	// Are we using more than ZFS has?

--- a/ZFSin/zfs/include/sys/kstat_windows.h
+++ b/ZFSin/zfs/include/sys/kstat_windows.h
@@ -154,6 +154,7 @@ typedef struct osx_kstat {
 	kstat_named_t zfs_vdev_initialize_value;
 	kstat_named_t zfs_autoimport_disable;
 	kstat_named_t metaslab_unload_delay;
+	kstat_named_t zfs_total_memory_limit;
 } osx_kstat_t;
 
 

--- a/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
@@ -184,6 +184,7 @@ osx_kstat_t osx_kstat = {
 	{ "zfs_vdev_initialize_value",		KSTAT_DATA_UINT64 },
 	{ "zfs_autoimport_disable",		KSTAT_DATA_UINT64 },
 	{ "metaslab_unload_delay",		KSTAT_DATA_UINT64 },	
+	{ "zfs_total_memory_limit",		KSTAT_DATA_UINT64 },
 };
 
 


### PR DESCRIPTION
Allow the user to set 'zfs_total_memory_limit' as long as it is in the range 2GB to total_memory (total_memory is currently 50% of total RAM).