### PR TITLE
ZFSin crash on zpool remove

### DIFF
--- a/ZFSin/zfs/module/zfs/metaslab.c
+++ b/ZFSin/zfs/module/zfs/metaslab.c
@@ -848,9 +848,10 @@ metaslab_group_passivate(metaslab_group_t *mg)
 	mg->mg_prev = NULL;
 	mg->mg_next = NULL;
 	if (mg->mg_kstat != NULL) {
-		metaslab_group_kstat_t* data = mg->mg_kstat->ks_data;
+		kmem_free(mg->mg_kstat->ks_data, sizeof(metaslab_group_kstat_t));
+		mg->mg_kstat->ks_data = NULL;
 		kstat_delete(mg->mg_kstat);
-		kmem_free(data, sizeof(metaslab_group_kstat_t));
+		mg->mg_kstat = NULL;
 	}
 	mutex_destroy(&mg->mg_kstat_lock);
 }

--- a/ZFSin/zfs/module/zfs/vdev_removal.c
+++ b/ZFSin/zfs/module/zfs/vdev_removal.c
@@ -1504,6 +1504,7 @@ spa_vdev_remove_thread(void *arg)
 		ASSERT0(range_tree_space(svr->svr_allocd_segs));
 		vdev_remove_complete(spa);
 	}
+	thread_exit();
 }
 
 void


### PR DESCRIPTION
 1. Fixed memory corruption in 'metaslab_unload' due to
    'metaslab_group_passivate' function not setting the freed pointer to
    NULL.
    2. Fixed '.\zfsinstaller.exe uninstall .\ZFSin\ZFSin.inf' command hang
       after zpool removal due to 'spa_vdev_remove_thread' not calling
    'thread_exit()' during exit.