### PR TITLE
Port 'zfs_dirty_data_sync_percent' change from Linux

### DIFF
--- a/ZFSin/zfs/include/sys/dsl_pool.h
+++ b/ZFSin/zfs/include/sys/dsl_pool.h
@@ -57,7 +57,7 @@ struct dsl_crypto_params;
 
 extern uint64_t zfs_dirty_data_max;
 extern uint64_t zfs_dirty_data_max_max;
-extern uint64_t zfs_dirty_data_sync;
+extern int zfs_dirty_data_sync_percent;
 extern int zfs_dirty_data_max_percent;
 extern int zfs_dirty_data_max_max_percent;
 extern int zfs_delay_min_dirty_percent;

--- a/ZFSin/zfs/include/sys/kstat_windows.h
+++ b/ZFSin/zfs/include/sys/kstat_windows.h
@@ -76,7 +76,7 @@ typedef struct osx_kstat {
 	kstat_named_t arc_reduce_dnlc_percent;
 	kstat_named_t arc_lotsfree_percent;
 	kstat_named_t zfs_dirty_data_max;
-	kstat_named_t zfs_dirty_data_sync;
+	kstat_named_t zfs_dirty_data_sync_percent;
 	kstat_named_t zfs_delay_max_ns;
 	kstat_named_t zfs_delay_min_dirty_percent;
 	kstat_named_t zfs_delay_scale;

--- a/ZFSin/zfs/module/zfs/dsl_pool.c
+++ b/ZFSin/zfs/module/zfs/dsl_pool.c
@@ -108,7 +108,7 @@ int zfs_dirty_data_max_max_percent = 25;
 /*
  * If there is at least this much dirty data, push out a txg.
  */
-uint64_t zfs_dirty_data_sync = 64 * 1024 * 1024;
+int zfs_dirty_data_sync_percent = 20;
 
 /*
  * Once there is this amount of dirty data, the dmu_tx_delay() will kick in
@@ -914,10 +914,12 @@ dsl_pool_need_dirty_delay(dsl_pool_t *dp)
 {
 	uint64_t delay_min_bytes =
 	    zfs_dirty_data_max * zfs_delay_min_dirty_percent / 100;
+	uint64_t dirty_min_bytes =
+		zfs_dirty_data_max * zfs_dirty_data_sync_percent / 100;
 	boolean_t rv;
 
 	mutex_enter(&dp->dp_lock);
-	if (dp->dp_dirty_total > zfs_dirty_data_sync)
+	if (dp->dp_dirty_total > dirty_min_bytes)
 		txg_kick(dp);
 	rv = (dp->dp_dirty_total > delay_min_bytes);
 	mutex_exit(&dp->dp_lock);

--- a/ZFSin/zfs/module/zfs/txg.c
+++ b/ZFSin/zfs/module/zfs/txg.c
@@ -530,6 +530,8 @@ txg_sync_thread(void *arg)
 		clock_t timer, timeout;
 		uint64_t txg;
 		uint64_t ndirty;
+		uint64_t dirty_min_bytes =
+			zfs_dirty_data_max * zfs_dirty_data_sync_percent / 100;
 
 		timeout = zfs_txg_timeout * hz;
 
@@ -543,7 +545,7 @@ txg_sync_thread(void *arg)
 		    !tx->tx_exiting && timer > 0 &&
 		    tx->tx_synced_txg >= tx->tx_sync_txg_waiting &&
 		    !txg_has_quiesced_to_sync(dp) &&
-		    dp->dp_dirty_total < zfs_dirty_data_sync) {
+		    dp->dp_dirty_total < dirty_min_bytes) {
 			dprintf("waiting; tx_synced=%llu waiting=%llu dp=%p\n",
 			    tx->tx_synced_txg, tx->tx_sync_txg_waiting, dp);
 			txg_thread_wait(tx, &cpr, &tx->tx_sync_more_cv, timer);

--- a/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_kstat_windows.c
@@ -107,7 +107,7 @@ osx_kstat_t osx_kstat = {
 	{"arc_reduce_dnlc_percent",		KSTAT_DATA_INT64  },
 	{"arc_lotsfree_percent",		KSTAT_DATA_INT64  },
 	{"zfs_dirty_data_max",			KSTAT_DATA_INT64  },
-	{"zfs_dirty_data_sync",			KSTAT_DATA_INT64  },
+	{"zfs_dirty_data_sync_percent",		KSTAT_DATA_INT64  },
 	{"zfs_delay_max_ns",			KSTAT_DATA_INT64  },
 	{"zfs_delay_min_dirty_percent",	KSTAT_DATA_INT64  },
 	{"zfs_delay_scale",				KSTAT_DATA_INT64  },
@@ -278,8 +278,8 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 			ks->arc_lotsfree_percent.value.i64;
 		zfs_dirty_data_max =
 			ks->zfs_dirty_data_max.value.i64;
-		zfs_dirty_data_sync =
-			ks->zfs_dirty_data_sync.value.i64;
+		zfs_dirty_data_sync_percent =
+			ks->zfs_dirty_data_sync_percent.value.i64;
 		zfs_delay_max_ns =
 			ks->zfs_delay_max_ns.value.i64;
 		zfs_delay_min_dirty_percent =
@@ -475,8 +475,8 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 			arc_lotsfree_percent;
 		ks->zfs_dirty_data_max.value.i64 =
 			zfs_dirty_data_max;
-		ks->zfs_dirty_data_sync.value.i64 =
-			zfs_dirty_data_sync;
+		ks->zfs_dirty_data_sync_percent.value.i64 =
+			zfs_dirty_data_sync_percent;
 		ks->zfs_delay_max_ns.value.i64 =
 			zfs_delay_max_ns;
 		ks->zfs_delay_min_dirty_percent.value.i64 =


### PR DESCRIPTION
With zfs_dirty_data_sync too-frequent TXG sync causes excessive write  inflation, so removed 'zfs_dirty_data_sync' config and added 'zfs_dirty_data_sync_percent' which is set to 20% of 'zfs_dirty_data_max'.