### PR TITLE
Adding zpool API to retrieve allocated and total size of a zpool

### DIFF
--- a/ZFSin/zfs/include/sys/zfs_ioctl.h
+++ b/ZFSin/zfs/include/sys/zfs_ioctl.h
@@ -654,6 +654,17 @@ typedef struct zfs_useracct {
 	uint64_t zu_space;
 } zfs_useracct_t;
 
+#define ZPOOL_GET_SIZE_STATS	CTL_CODE(ZFSIOCTL_TYPE, 0xFFF, METHOD_BUFFERED, FILE_ANY_ACCESS)
+
+// Input/Output for IOCTL - ZPOOL_GET_SIZE_STATS
+typedef struct {
+	char zpool_name[MAXNAMELEN];
+	uint64_t size;
+	uint64_t alloc;
+} zpool_size_stats;
+
+
+
 #define	ZFSDEV_MAX_MINOR	(1 << 16)
 #define	ZFS_MIN_MINOR	(ZFSDEV_MAX_MINOR + 1)
 

--- a/ZFSin/zfs/include/sys/zfs_windows.h
+++ b/ZFSin/zfs/include/sys/zfs_windows.h
@@ -156,6 +156,6 @@ extern NTSTATUS ioctl_query_unique_id(PDEVICE_OBJECT, PIRP, PIO_STACK_LOCATION);
 extern NTSTATUS ioctl_mountdev_query_suggested_link_name(PDEVICE_OBJECT, PIRP, PIO_STACK_LOCATION);
 extern NTSTATUS ioctl_mountdev_query_stable_guid(PDEVICE_OBJECT, PIRP, PIO_STACK_LOCATION);
 extern NTSTATUS ioctl_query_stable_guid(PDEVICE_OBJECT, PIRP, PIO_STACK_LOCATION);
-
+extern NTSTATUS zpool_get_size_stats(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STACK_LOCATION IrpSp);
 
 #endif

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -79,7 +79,6 @@
 //#include <vfs/vfs_support.h>
 //#include <sys/ioccom.h>
 
-
 PDEVICE_OBJECT ioctlDeviceObject = NULL;
 PDEVICE_OBJECT fsDiskDeviceObject = NULL;
 #ifdef DEBUG_IOCOUNT
@@ -3977,6 +3976,10 @@ ioctlDispatcher(
 			case KSTAT_IOC_WRITE:
 				dprintf("KSTAT_IOC_WRITE\n");
 				Status = spl_kstat_write(DeviceObject, Irp, IrpSp);
+				break;
+			case ZPOOL_GET_SIZE_STATS:
+				dprintf("ZPOOL_GET_SIZE_STATS\n");
+				Status = zpool_get_size_stats(DeviceObject, Irp, IrpSp);
 				break;
 			default:
 				dprintf("**** unknown Windows IOCTL: 0x%lx\n", cmd);


### PR DESCRIPTION
Given a zpool name, the API returns allocated space and total size of zpool