### PR TITLE
zpool counters added to perfmon

### DIFF
--- a/ZFSin/OpenZFS.man
+++ b/ZFSin/OpenZFS.man
@@ -123,6 +123,86 @@
 						type         = "perf_counter_large_rawcount"
 						detailLevel  = "standard">
 					</counter>
+					<counter
+						id           = "10"
+						uri          = "ZFSin.vsx_active_queue_sync_read"
+						name         = "Active_Sync_Reads"
+						struct       = "vsx_active_queue_sync_read"
+						field        = "vsx_active_queue_sync_read"
+						description  = "vsx_active_queue_sync_read"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "11"
+						uri          = "ZFSin.vsx_active_queue_sync_write"
+						name         = "Active_Sync_Writes"
+						struct       = "vsx_active_queue_sync_write"
+						field        = "vsx_active_queue_sync_write"
+						description  = "vsx_active_queue_sync_write"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "12"
+						uri          = "ZFSin.vsx_active_queue_async_read"
+						name         = "Active_Async_Reads"
+						struct       = "vsx_active_queue_async_read"
+						field        = "vsx_active_queue_async_read"
+						description  = "vsx_active_queue_async_read"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "13"
+						uri          = "ZFSin.vsx_active_queue_async_write"
+						name         = "Active_Async_Writes"
+						struct       = "vsx_active_queue_async_write"
+						field        = "vsx_active_queue_async_write"
+						description  = "vsx_active_queue_async_write"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "14"
+						uri          = "ZFSin.vsx_pend_queue_sync_read "
+						name         = "Pending_Sync_Reads"
+						struct       = "vsx_pend_queue_sync_read"
+						field        = "vsx_pend_queue_sync_read"
+						description  = "vsx_pend_queue_sync_read"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "15"
+						uri          = "ZFSin.vsx_pend_queue_sync_write "
+						name         = "Pending_Sync_Writes"
+						struct       = "vsx_pend_queue_sync_write"
+						field        = "vsx_pend_queue_sync_write"
+						description  = "vsx_pend_queue_sync_write"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "16"
+						uri          = "ZFSin.vsx_pend_queue_async_read"
+						name         = "Pending_Async_Reads"
+						struct       = "vsx_pend_queue_async_read"
+						field        = "vsx_pend_queue_async_read"
+						description  = "vsx_pend_queue_async_read"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "17"
+						uri          = "ZFSin.vsx_pend_queue_async_write "
+						name         = "Pending_Async_Writes"
+						struct       = "vsx_pend_queue_async_write"
+						field        = "vsx_pend_queue_async_write"
+						description  = "vsx_pend_queue_async_write"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
 				</counterSet>
 			</provider>
 		</counters>

--- a/ZFSin/zfs/include/sys/zfs_ioctl.h
+++ b/ZFSin/zfs/include/sys/zfs_ioctl.h
@@ -676,6 +676,14 @@ typedef struct {
 	unsigned __int64	ddt_entry_count;	/* number of elments in ddt */
 	unsigned __int64	ddt_dspace;			/* size of ddt on disk		*/
 	unsigned __int64	ddt_mspace;			/* size of ddt in-core		*/
+	unsigned __int64	vsx_active_queue_sync_read;
+	unsigned __int64	vsx_active_queue_sync_write;
+	unsigned __int64	vsx_active_queue_async_read;
+	unsigned __int64	vsx_active_queue_async_write;
+	unsigned __int64	vsx_pend_queue_sync_read;
+	unsigned __int64	vsx_pend_queue_sync_write;
+	unsigned __int64	vsx_pend_queue_async_read;
+	unsigned __int64	vsx_pend_queue_async_write;
 	char zpool_name[MAXNAMELEN];
 } zpool_perf_counters;
 


### PR DESCRIPTION
Added counters : 
- Active_Sync_Reads          
- Active_Sync_Writes 
- Active_Async_Reads 
- Active_Async_Writes 
- Pend_Sync_Reads 
- Pend_Sync_Writes 
- Pend_Async_Reads 
- Pend_Async_Writes 