### PR TITLE
ZFSin set NumberOfPhysicalBreaks = 0x21 this will make zvol perform better when the blockssize is >=128K

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
@@ -200,6 +200,7 @@ wzvol_HwFindAdapter(
 	pConfigInfo->VirtualDevice = TRUE;                        // Inidicate no real hardware.
 	pConfigInfo->WmiDataProvider = TRUE;                        // Indicate WMI provider.
 	pConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;      // Indicate unlimited.
+	pConfigInfo->NumberOfPhysicalBreaks = 0x21;
 	pConfigInfo->AlignmentMask = 0x3;                         // Indicate DWORD alignment.
 	pConfigInfo->CachesData = FALSE;                       // Indicate miniport wants flush and shutdown notification.
 	pConfigInfo->ScatterGather = TRUE;                        // Indicate scatter-gather (explicit setting needed for Win2003 at least).

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol.c
@@ -200,7 +200,7 @@ wzvol_HwFindAdapter(
 	pConfigInfo->VirtualDevice = TRUE;                        // Inidicate no real hardware.
 	pConfigInfo->WmiDataProvider = TRUE;                        // Indicate WMI provider.
 	pConfigInfo->MaximumTransferLength = SP_UNINITIALIZED_VALUE;      // Indicate unlimited.
-	pConfigInfo->NumberOfPhysicalBreaks = 0x21;
+	pConfigInfo->NumberOfPhysicalBreaks = 0x21;			  // 128K IO size
 	pConfigInfo->AlignmentMask = 0x3;                         // Indicate DWORD alignment.
 	pConfigInfo->CachesData = FALSE;                       // Indicate miniport wants flush and shutdown notification.
 	pConfigInfo->ScatterGather = TRUE;                        // Indicate scatter-gather (explicit setting needed for Win2003 at least).


### PR DESCRIPTION
By changing 'NumberOfPhysicalBreaks=0x21' we are able to improve ZFSin performance by 50%.
 Default 'NumberOfPhysicalBreaks' is set to 0x11, that is 64K, so for every 128K read/write storport will send two request to ZFSin, now changing the value to 0x21 reduced the number of request by half and thus improving the performance.
Also we can see that the  performance is now exactly matching with the Linux performance.

```
Windows:
---------------------------------------------------------------------------------------------------------------------------------------
Disk Type				Operation	block-size	threads		i/o       MB/sec    queue  cpu%    cpu%	   
							(vdbench)			rate      1024**2   depth  sys+u   sys	   
---------------------------------------------------------------------------------------------------------------------------------------
Windows:
zvol(1vdev)				Write(100%)	128K		16		 1152.4   144.06    15.9   8.1   7.8
zvol(2vdev)				Write(100%)	128K		16		 2162.3   270.29    15.9  13.1  12.6
zvol(3vdev)				Write(100%)	128K		16		 2996.9   374.62    15.9  15.5  15.1	

zvol(1vdev)				Write(100%)	128K		16		 3107.4   388.42    15.8   9.9   9.2	NumberOfPhysicalBreaks = 0x21
zvol(2vdev)				Write(100%)	128K		16		 6148.6   768.57    15.7  14.1  13.2    NumberOfPhysicalBreaks = 0x21
zvol(3vdev)				Write(100%)	128K		16		 7930.1   991.26    13.7  13.7  12.9    NumberOfPhysicalBreaks = 0x21

Linux:

zvol(1vdev)				Write(100%)	128K		16		 3046.2   380.77    15.9   6.3   5.8
zvol(2vdev)				Write(100%)	128K		16		 6134.4   766.80    15.7  12.2  11.2
zvol(3vdev)				Write(100%)	128K		16		 7882.3   985.28    14.0  17.3  16.0
	
```

Link: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/storport/ns-storport-_port_configuration_information