### PR TITLE
Exporting 'zpool iostat latency' stats to perfmon

### DIFF
--- a/ZFSin/OpenZFS.man
+++ b/ZFSin/OpenZFS.man
@@ -203,6 +203,176 @@
 						type         = "perf_counter_large_rawcount"
 						detailLevel  = "standard">
 					</counter>
+					<counter
+						id           = "18"
+						uri          = "ZFSin.vsx_queue_histo_sync_read_time"
+						name         = "Wait_Time_Sync_Read_ns"
+						struct       = "vsx_queue_histo_sync_read_time"
+						field        = "vsx_queue_histo_sync_read_time"
+						description  = "vsx_queue_histo_sync_read_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "19"
+						uri          = "ZFSin.vsx_queue_histo_sync_read_count"
+						name         = "Wait_Count_Sync_Read"
+						struct       = "vsx_queue_histo_sync_read_count"
+						field        = "vsx_queue_histo_sync_read_count"
+						description  = "vsx_queue_histo_sync_read_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "20"
+						uri          = "ZFSin.vsx_queue_histo_async_read_time"
+						name         = "Wait_Time_Async_Read_ns"
+						struct       = "vsx_queue_histo_async_read_time"
+						field        = "vsx_queue_histo_async_read_time"
+						description  = "vsx_queue_histo_async_read_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "21"
+						uri          = "ZFSin.vsx_queue_histo_async_read_count"
+						name         = "Wait_Count_Async_Read"
+						struct       = "vsx_queue_histo_async_read_count"
+						field        = "vsx_queue_histo_async_read_count"
+						description  = "vsx_queue_histo_async_read_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "22"
+						uri          = "ZFSin.vsx_queue_histo_sync_write_time"
+						name         = "Wait_Time_Sync_Write_ns"
+						struct       = "vsx_queue_histo_sync_write_time"
+						field        = "vsx_queue_histo_sync_write_time"
+						description  = "vsx_queue_histo_sync_write_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "23"
+						uri          = "ZFSin.vsx_queue_histo_sync_write_count"
+						name         = "Wait_Count_Sync_Write"
+						struct       = "vsx_queue_histo_sync_write_count"
+						field        = "vsx_queue_histo_sync_write_count"
+						description  = "vsx_queue_histo_sync_write_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "24"
+						uri          = "ZFSin.vsx_queue_histo_async_write_time"
+						name         = "Wait_Time_Async_Write_ns"
+						struct       = "vsx_queue_histo_async_write_time"
+						field        = "vsx_queue_histo_async_write_time"
+						description  = "vsx_queue_histo_async_write_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "25"
+						uri          = "ZFSin.vsx_queue_histo_async_write_count"
+						name         = "Wait_Count_Async_Write"
+						struct       = "vsx_queue_histo_async_write_count"
+						field        = "vsx_queue_histo_async_write_count"
+						description  = "vsx_queue_histo_async_write_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "26"
+						uri          = "ZFSin.vsx_total_histo_read_time"
+						name         = "Wait_Time_Total_Read_ns"
+						struct       = "vsx_total_histo_read_time"
+						field        = "vsx_total_histo_read_time"
+						description  = "vsx_total_histo_read_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "27"
+						uri          = "ZFSin.vsx_total_histo_read_count"
+						name         = "Wait_Count_Total_Read"
+						struct       = "vsx_total_histo_read_count"
+						field        = "vsx_total_histo_read_count"
+						description  = "vsx_total_histo_read_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "28"
+						uri          = "ZFSin.vsx_total_histo_write_time"
+						name         = "Wait_Time_Total_Write_ns"
+						struct       = "vsx_total_histo_write_time"
+						field        = "vsx_total_histo_write_time"
+						description  = "vsx_total_histo_write_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "29"
+						uri          = "ZFSin.vsx_total_histo_write_count"
+						name         = "Wait_Count_Total_Write"
+						struct       = "vsx_total_histo_write_count"
+						field        = "vsx_total_histo_write_count"
+						description  = "vsx_total_histo_write_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "30"
+						uri          = "ZFSin.vsx_disk_histo_read_time"
+						name         = "Wait_Time_Disk_Read_ns"
+						struct       = "vsx_disk_histo_read_time"
+						field        = "vsx_disk_histo_read_time"
+						description  = "vsx_disk_histo_read_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "31"
+						uri          = "ZFSin.vsx_disk_histo_read_count"
+						name         = "Wait_Count_Disk_Read"
+						struct       = "vsx_disk_histo_read_count"
+						field        = "vsx_disk_histo_read_count"
+						description  = "vsx_disk_histo_read_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "32"
+						uri          = "ZFSin.vsx_disk_histo_write_time"
+						name         = "Wait_Time_Disk_Write_ns"
+						struct       = "vsx_disk_histo_write_time"
+						field        = "vsx_disk_histo_write_time"
+						description  = "vsx_disk_histo_write_time"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "33"
+						uri          = "ZFSin.vsx_disk_histo_write_count"
+						name         = "Wait_Count_Disk_Write"
+						struct       = "vsx_disk_histo_write_count"
+						field        = "vsx_disk_histo_write_count"
+						description  = "vsx_disk_histo_write_count"
+						type         = "perf_counter_bulk_count"
+						detailLevel  = "standard">
+					</counter>
+					<counter
+						id           = "34"
+						uri          = "ZFSin.dp_dirty_total_io"
+						name         = "Dirty_Data_Bytes"
+						struct       = "dp_dirty_total_io"
+						field        = "dp_dirty_total_io"
+						description  = "dp_dirty_total_io"
+						type         = "perf_counter_large_rawcount"
+						detailLevel  = "standard">
+					</counter>
 				</counterSet>
 			</provider>
 		</counters>

--- a/ZFSin/zfs/cmd/zpool/zpool_main.c
+++ b/ZFSin/zfs/cmd/zpool/zpool_main.c
@@ -3940,7 +3940,7 @@ single_histo_average(uint64_t *histo, unsigned int buckets)
 
 static void
 print_iostat_queues(iostat_cbdata_t *cb, nvlist_t *oldnv,
-    nvlist_t *newnv, double scale)
+    nvlist_t *newnv)
 {
 	int i;
 	uint64_t val;
@@ -3972,7 +3972,7 @@ print_iostat_queues(iostat_cbdata_t *cb, nvlist_t *oldnv,
 		format = ZFS_NICENUM_1024;
 
 	for (i = 0; i < ARRAY_SIZE(names); i++) {
-		val = nva[i].data[0] * scale;
+		val = nva[i].data[0];
 		print_one_stat(val, format, column_width, cb->cb_scripted);
 	}
 
@@ -3981,7 +3981,7 @@ print_iostat_queues(iostat_cbdata_t *cb, nvlist_t *oldnv,
 
 static void
 print_iostat_latency(iostat_cbdata_t *cb, nvlist_t *oldnv,
-    nvlist_t *newnv, double scale)
+    nvlist_t *newnv)
 {
 	int i;
 	uint64_t val;
@@ -4012,7 +4012,8 @@ print_iostat_latency(iostat_cbdata_t *cb, nvlist_t *oldnv,
 	/* Print our avg latencies on the line */
 	for (i = 0; i < ARRAY_SIZE(names); i++) {
 		/* Compute average latency for a latency histo */
-		val = single_histo_average(nva[i].data, nva[i].count) * scale;
+		val = single_histo_average(nva[i].data, nva[i].count);
+
 		print_one_stat(val, format, column_width, cb->cb_scripted);
 	}
 	free_calc_stats(nva, ARRAY_SIZE(names));
@@ -4160,9 +4161,9 @@ print_vdev_stats(zpool_handle_t *zhp, const char *name, nvlist_t *oldnv,
 		print_iostat_default(calcvs, cb, scale);
 	}
 	if (cb->cb_flags & IOS_LATENCY_M)
-		print_iostat_latency(cb, oldnv, newnv, scale);
+		print_iostat_latency(cb, oldnv, newnv);
 	if (cb->cb_flags & IOS_QUEUES_M)
-		print_iostat_queues(cb, oldnv, newnv, scale);
+		print_iostat_queues(cb, oldnv, newnv);
 	if (cb->cb_flags & IOS_ANYHISTO_M) {
 		printf("\n");
 		print_iostat_histos(cb, oldnv, newnv, scale, name);

--- a/ZFSin/zfs/include/sys/zfs_ioctl.h
+++ b/ZFSin/zfs/include/sys/zfs_ioctl.h
@@ -665,6 +665,13 @@ typedef struct {
 	uint64_t alloc;
 } zpool_size_stats;
 
+typedef struct
+{
+	uint64_t total;
+	uint64_t count;
+}stat_pair;
+
+
 
 #define ZPOOL_GET_IOPS_THRPUT_STATS	CTL_CODE(ZFSIOCTL_TYPE, 0xFFE, METHOD_BUFFERED, FILE_ANY_ACCESS)
 
@@ -686,6 +693,23 @@ typedef struct {
 	unsigned __int64	vsx_pend_queue_sync_write;
 	unsigned __int64	vsx_pend_queue_async_read;
 	unsigned __int64	vsx_pend_queue_async_write;
+	unsigned __int64	vsx_queue_histo_sync_read_time;
+	unsigned __int64	vsx_queue_histo_sync_read_count;
+	unsigned __int64	vsx_queue_histo_async_read_time;
+	unsigned __int64	vsx_queue_histo_async_read_count;
+	unsigned __int64	vsx_queue_histo_sync_write_time;
+	unsigned __int64	vsx_queue_histo_sync_write_count;
+	unsigned __int64	vsx_queue_histo_async_write_time;
+	unsigned __int64	vsx_queue_histo_async_write_count;
+	unsigned __int64	vsx_total_histo_read_time;
+	unsigned __int64	vsx_total_histo_read_count;
+	unsigned __int64	vsx_total_histo_write_time;
+	unsigned __int64	vsx_total_histo_write_count;
+	unsigned __int64	vsx_disk_histo_read_time;
+	unsigned __int64	vsx_disk_histo_read_count;
+	unsigned __int64	vsx_disk_histo_write_time;
+	unsigned __int64	vsx_disk_histo_write_count;
+	unsigned __int64	dp_dirty_total_io;
 	char zpool_name[MAXNAMELEN];
 } zpool_perf_counters;
 
@@ -710,6 +734,7 @@ extern int zfs_secpolicy_destroy_perms(const char *, cred_t *);
 extern int zfs_unmount_snap(const char *);
 extern void zfs_destroy_unmount_origin(const char *);
 extern int getzfsvfs_impl(struct objset *, struct zfsvfs **);
+extern void latency_stats(uint64_t* histo, unsigned int buckets, stat_pair* lat);
 
 enum zfsdev_state_type {
 	ZST_ONEXIT,


### PR DESCRIPTION
To fetch the average latency values for respective read and write (total_wait, disk_wait, async_wait, sync_wait), we need to calculate (wait_time/wait_count).