### PR TITLE
Fixed data miscompare issue when the backend disk returns error to ZFSin

### DIFF
--- a/ZFSin/zfs/module/zfs/zil.c
+++ b/ZFSin/zfs/module/zfs/zil.c
@@ -1260,7 +1260,6 @@ zil_lwb_write_done(zio_t *zio)
 		for (zcw = list_head(&lwb->lwb_waiters); zcw != NULL;
 				zcw = list_next(&lwb->lwb_waiters, zcw)) {
 			mutex_enter(&zcw->zcw_lock);
-			ASSERT(list_link_active(&zcw->zcw_node));
 			ASSERT3P(zcw->zcw_lwb, ==, lwb);
 			zcw->zcw_zio_error = zio->io_error;
 			mutex_exit(&zcw->zcw_lock);


### PR DESCRIPTION
Ideally the application should get an error or wait until the admin
fixes the disk error and run 'zpool clear' command. But without this
fix ZFSin was returning success even when the write failed.

Jenkins test result
http://10.200.0.86:8080/job/ZFS-Test-Suite/52/console