### PR TITLE
ssv-20428-addedlogs-dcaf-zvol-failed-issue

### DIFF
--- a/ZFSin/ZFSin.vcxproj
+++ b/ZFSin/ZFSin.vcxproj
@@ -503,10 +503,12 @@
       <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
     </ClCompile>
     <ClCompile Include="zfs\module\zfs\zfs_vnops_windows.c">
-      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</WppEnabled>
       <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
       <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+      <WppTraceFunction Condition="'$(Configuration)|$(Platform)'=='Release|x64'">TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);</WppTraceFunction>
     </ClCompile>
     <ClCompile Include="zfs\module\zfs\zfs_vnops_windows_lib.c">
       <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>

--- a/ZFSin/ZFSin.vcxproj
+++ b/ZFSin/ZFSin.vcxproj
@@ -506,9 +506,11 @@
       <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </UndefinePreprocessorDefinitions>
       <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</WppEnabled>
-      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">WPPFILE</UndefinePreprocessorDefinitions>
-      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</WppEnabled>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </UndefinePreprocessorDefinitions>
+      <WppEnabled Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</WppEnabled>
       <WppTraceFunction Condition="'$(Configuration)|$(Platform)'=='Release|x64'">TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);</WppTraceFunction>
+      <WppTraceFunction Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">TraceEvent{FLAGS=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);</WppTraceFunction>
     </ClCompile>
     <ClCompile Include="zfs\module\zfs\zfs_vnops_windows_lib.c">
       <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WPPFILE</UndefinePreprocessorDefinitions>

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -4952,7 +4952,9 @@ NTSTATUS pnp_query_di(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STACK_LOCATION 
 			zv = zvol_name2minor(&vendorUniqueId[8], &minorNum);
 			if (zv) {
 				zvol_state_t* pzvDebug = (zvol_state_t*)zv;
-				TraceEvent(TRACE_INFO, "%s:%d: querying DI interface for zvol:%s,zvol size=%llu,lun_id=%d,zv_target_id=%d,zv_minor=%d,zv_total_opens=%d\n", __func__, __LINE__, pzvDebug->zv_name, pzvDebug->zv_volsize, pzvDebug->zv_lun_id, pzvDebug->zv_target_id, pzvDebug->zv_minor, pzvDebug->zv_total_opens);
+				TraceEvent(TRACE_INFO, "%s:%d: querying DI interface for zvol:%s, zvol size=%llu, lun_id=%d, zv_target_id=%d, zv_minor=%d, zv_total_opens=%d\n",
+					__func__, __LINE__, pzvDebug->zv_name, pzvDebug->zv_volsize, pzvDebug->zv_lun_id,
+					pzvDebug->zv_target_id, pzvDebug->zv_minor, pzvDebug->zv_total_opens);
 			}
 
 			// check that the minor number is non-zero: that signifies the zvol has fully completed its bringup phase.

--- a/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
+++ b/ZFSin/zfs/module/zfs/zfs_vnops_windows.c
@@ -74,6 +74,7 @@
 #include <sys/unistd.h>
 #include <sys/zfs_windows.h>
 #include <sys/kstat.h>
+#include <sys/zvol.h>
 //#include <miscfs/fifofs/fifo.h>
 //#include <miscfs/specfs/specdev.h>
 //#include <vfs/vfs_support.h>
@@ -4949,6 +4950,11 @@ NTSTATUS pnp_query_di(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STACK_LOCATION 
 			extern PVOID zvol_name2minor(const char* name, minor_t * minor);
 			PCHAR vendorUniqueId = (PCHAR)IrpSp->Parameters.QueryInterface.InterfaceSpecificData;
 			zv = zvol_name2minor(&vendorUniqueId[8], &minorNum);
+			if (zv) {
+				zvol_state_t* pzvDebug = (zvol_state_t*)zv;
+				TraceEvent(TRACE_INFO, "%s:%d: querying DI interface for zvol:%s,zvol size=%llu,lun_id=%d,zv_target_id=%d,zv_minor=%d,zv_total_opens=%d\n", __func__, __LINE__, pzvDebug->zv_name, pzvDebug->zv_volsize, pzvDebug->zv_lun_id, pzvDebug->zv_target_id, pzvDebug->zv_minor, pzvDebug->zv_total_opens);
+			}
+
 			// check that the minor number is non-zero: that signifies the zvol has fully completed its bringup phase.
 			if (zv && minorNum) {
 				extern void IncZvolRef(PVOID Context);
@@ -4973,5 +4979,8 @@ NTSTATUS pnp_query_di(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STACK_LOCATION 
 	}
 	else
 		status = STATUS_NOT_IMPLEMENTED;
+		
+	TraceEvent(TRACE_INFO, "%s:%d: Returning status 0x%x\n", __func__, __LINE__, status);
+
 	return (status);
 }

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -625,7 +625,9 @@ ScsiOpReadCapacity16(
 	blockSize = MP_BLOCK_SIZE;
 	maxBlocks = (zv->zv_volsize / blockSize) - 1;
 
-	dprintf("%s:%d Block Size: 0x%x Total Blocks: 0x%llx targetid:%d lun:%d,volname:%s,zv_volsize=%llu\n", __func__, __LINE__, blockSize, maxBlocks, pSrb->TargetId, pSrb->Lun, zv->zv_name, zv->zv_volsize);
+	dprintf("%s:%d Block Size: 0x%x Total Blocks: 0x%llx targetid:%d lun:%d, volname:%s, zv_volsize=%llu\n",
+		__func__, __LINE__, blockSize, maxBlocks, pSrb->TargetId, pSrb->Lun, zv->zv_name, zv->zv_volsize);
+
 	REVERSE_BYTES(&readCapacity->BytesPerBlock, &blockSize);
 	REVERSE_BYTES_QUAD(&readCapacity->LogicalBlockAddress.QuadPart, &maxBlocks);
 	lppFactor = zv->zv_volblocksize / MP_BLOCK_SIZE;
@@ -838,7 +840,10 @@ wzvol_WkRtn(__in PVOID pWkParms)                          // Parm list pointer.
 	TraceEvent(8,"%s:%d: MpWkRtn pSrb: 0x%p, pSrb->DataBuffer: 0x%p\n", __func__, __LINE__, pSrb, pSrb->DataBuffer);
 	
 	if (sectorOffset >= zv->zv_volsize) {      // Starting sector beyond the bounds?
-		dprintf("%s:%d invalid starting sector: %d for zvol:%s,volsize=%llu,minor=%d,target_id=%d,lun_id=%d\n", __func__, __LINE__, startingSector, zv->zv_name, zv->zv_volsize, zv->zv_minor, zv->zv_target_id, zv->zv_lun_id);
+		dprintf("%s:%d invalid starting sector: %d for zvol:%s, volsize=%llu, minor=%d, target_id=%d, lun_id=%d\n",
+			__func__, __LINE__, startingSector, zv->zv_name, zv->zv_volsize, zv->zv_minor,
+			zv->zv_target_id, zv->zv_lun_id);
+		
 		status = SRB_STATUS_INVALID_REQUEST;
 		goto Done;
 	}

--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
@@ -625,7 +625,7 @@ ScsiOpReadCapacity16(
 	blockSize = MP_BLOCK_SIZE;
 	maxBlocks = (zv->zv_volsize / blockSize) - 1;
 
-	dprintf("Block Size: 0x%x Total Blocks: 0x%llx\n", blockSize, maxBlocks);
+	dprintf("%s:%d Block Size: 0x%x Total Blocks: 0x%llx targetid:%d lun:%d,volname:%s,zv_volsize=%llu\n", __func__, __LINE__, blockSize, maxBlocks, pSrb->TargetId, pSrb->Lun, zv->zv_name, zv->zv_volsize);
 	REVERSE_BYTES(&readCapacity->BytesPerBlock, &blockSize);
 	REVERSE_BYTES_QUAD(&readCapacity->LogicalBlockAddress.QuadPart, &maxBlocks);
 	lppFactor = zv->zv_volblocksize / MP_BLOCK_SIZE;
@@ -836,9 +836,9 @@ wzvol_WkRtn(__in PVOID pWkParms)                          // Parm list pointer.
 
 	TraceEvent(8,"%s:%d: MpWkRtn Action: %X, starting sector: 0x%llX, sector offset: 0x%llX\n", __func__, __LINE__, pWkRtnParms->Action, startingSector, sectorOffset);
 	TraceEvent(8,"%s:%d: MpWkRtn pSrb: 0x%p, pSrb->DataBuffer: 0x%p\n", __func__, __LINE__, pSrb, pSrb->DataBuffer);
-
+	
 	if (sectorOffset >= zv->zv_volsize) {      // Starting sector beyond the bounds?
-		dprintf("%s: invalid starting sector: %d\n", __func__, startingSector);
+		dprintf("%s:%d invalid starting sector: %d for zvol:%s,volsize=%llu,minor=%d,target_id=%d,lun_id=%d\n", __func__, __LINE__, startingSector, zv->zv_name, zv->zv_volsize, zv->zv_minor, zv->zv_target_id, zv->zv_lun_id);
 		status = SRB_STATUS_INVALID_REQUEST;
 		goto Done;
 	}

--- a/ZFSin/zfs/module/zfs/zvol.c
+++ b/ZFSin/zfs/module/zfs/zvol.c
@@ -711,8 +711,9 @@ zvol_create_minor_impl(const char *name)
 	if (error == 0)
 		zv->zv_minor = minor; // zvol good to go and fully opened.
 
-	dprintf("%s:%d before returning zvol '%s',targetid=%d,lun_id=%d,zv_minor=%d,total_opens=%d,vol size=%llu,flags=%d\n",
-		__func__, __LINE__, zv->zv_name, zv->zv_target_id, zv->zv_lun_id, zv->zv_minor, zv->zv_total_opens, zv->zv_volsize, zv->zv_flags);
+	dprintf("%s:%d before returning zvol '%s',targetid=%d, lun_id=%d, zv_minor=%d, total_opens=%d, vol size=%llu, flags=%d\n",
+		__func__, __LINE__, zv->zv_name, zv->zv_target_id, zv->zv_lun_id, zv->zv_minor,
+		zv->zv_total_opens, zv->zv_volsize, zv->zv_flags);
 
 	return (0);
 }

--- a/ZFSin/zfs/module/zfs/zvol.c
+++ b/ZFSin/zfs/module/zfs/zvol.c
@@ -654,6 +654,8 @@ zvol_create_minor_impl(const char *name)
 	// Assign new TargetId and Lun
 	wzvol_assign_targetid(zv);
 
+	dprintf("%s:%d Assigned targetid for zvol:%s\n",
+		__func__, __LINE__, zv->zv_name);
 
 	/* get and cache the blocksize */
 	error = dmu_object_info(os, ZVOL_OBJ, &doi);
@@ -708,6 +710,9 @@ zvol_create_minor_impl(const char *name)
 	error = zvol_open_impl(zv, FWRITE, 0, NULL);
 	if (error == 0)
 		zv->zv_minor = minor; // zvol good to go and fully opened.
+
+	dprintf("%s:%d before returning zvol '%s',targetid=%d,lun_id=%d,zv_minor=%d,total_opens=%d,vol size=%llu,flags=%d\n",
+		__func__, __LINE__, zv->zv_name, zv->zv_target_id, zv->zv_lun_id, zv->zv_minor, zv->zv_total_opens, zv->zv_volsize, zv->zv_flags);
 
 	return (0);
 }


### PR DESCRIPTION
SSV-20428: One of the ZVOL failed after a RestartSSV while running HA-DCAF tests
https://dcsw.atlassian.net/browse/SSV-20428

Changes
SSY failed to get DI interface for the failed zvol. Added additional debug logs which could help if issue is reproduced again.

Added additional logs for files:-
         ZFSin/zfs/module/zfs/zfs_vnops_windows.c
         ZFSin/zfs/module/zfs/zfs_windows_zvol_scsi.c
         ZFSin/zfs/module/zfs/zvol.c

ZFSin/ZFSin.vcxproj:-

  WPP tracing was disabled for file 'zfs_vnops_windows.c' as it creates much noise using dprintf(). So added new couple of logs 
  using TraceEvent() functions. Now enbaled tracing only for TraceEvent() which was not used in this file earlier.
