### PR TITLE
ssv-20352: Provided default implementation for WMI method GetDiscoveredPortAttributes

### DIFF
--- a/ZFSin/zfs/module/zfs/zfs_windows_zvol_wmi.c
+++ b/ZFSin/zfs/module/zfs/zfs_windows_zvol_wmi.c
@@ -776,6 +776,21 @@ ExecuteWmiMethod(
 
             switch(MethodId) {
 
+                case GetDiscoveredPortAttributes: {
+                    PGetDiscoveredPortAttributes_OUT pGetDiscoveredPortAttributes = (PGetDiscoveredPortAttributes_OUT)pBuffer;
+                    sizeNeeded = GetDiscoveredPortAttributes_OUT_SIZE;
+
+                    if (OutBufferSize >= sizeNeeded) {
+                        memset(pGetDiscoveredPortAttributes, 0, sizeNeeded);
+                        pGetDiscoveredPortAttributes->HBAStatus = HBA_STATUS_ERROR_ILLEGAL_INDEX;
+                    }
+                    else {
+                        status = SRB_STATUS_DATA_OVERRUN;
+                    }
+
+                    break;
+                }
+
                 case RefreshInformation: {
 
                     // Do nothing.


### PR DESCRIPTION
Jira:- https://dcsw.atlassian.net/browse/SSV-20352

Issue:- The GetDiscoveredPortAttributes() wmi method was not implemented for the WMI class MSFC_HBAAdapterMethods. This was causing problem with SCVMM setup in customer environment.

Fix:- Implemented the default method for the WMI class. Returning the status as 'HBA_STATUS_ERROR_ILLEGAL_INDEX'(=6) because it was the status returned by the other actual FC adapter driver in the customer environment. 

To Test:- Execute the below WMI query from powershell and it should not return any error.

Get-WMIObject -Class MSFC_HBAAdapterMethods -Namespace root\wmi | ForEach-Object {$_.GetDiscoveredPortAttributes(0,0)}