### PR TITLE
Fix error message "cannot label <DRIVE>: unable to read disk capacity"

### DIFF
--- a/ZFSin/zfs/lib/libefi/rdwr_efi.c
+++ b/ZFSin/zfs/lib/libefi/rdwr_efi.c
@@ -381,7 +381,7 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 	size_t		length;
 	struct dk_gpt	*vptr;
 	struct uuid	uuid;
-	struct dk_cinfo	dki_info;
+	struct dk_cinfo	dki_info = { 0 };
 
 	if (read_disk_info(fd, &capacity, &lbsize) != 0)
 		return (-1);
@@ -393,10 +393,12 @@ efi_alloc_and_init(int fd, uint32_t nparts, struct dk_gpt **vtoc)
 	if (dki_info.dki_partition != 0)
 		return (-1);
 
+#ifndef _WIN32
 	if ((dki_info.dki_ctype == DKC_PCMCIA_MEM) ||
 	    (dki_info.dki_ctype == DKC_VBD) ||
 	    (dki_info.dki_ctype == DKC_UNKNOWN))
 		return (-1);
+#endif
 #endif
 
 	nblocks = NBLOCKS(nparts, lbsize);


### PR DESCRIPTION
Zpool create fails on Windows 2016 server with the error ""cannot label <DRIVE>: unable to read disk capacity".
https://dcsw.atlassian.net/browse/ZFS-1013 

Merging below commit from psp14 branch. 
https://github.com/DataCoreSoftware/ZFSin/pull/64/commits/366697628614f703569903fbdcd8c712872146f1