### PR TITLE
SSV-24707, SSV-24829: Fix multithreading, add option to skip All-zero blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,4 @@ ModelManifest.xml
 
 *.am
 
+*.pyc

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -179,12 +179,16 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
             if sample_size != -1:
                 bytes_total = sample_size
 
+            logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
+
             i = 0
             bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
             with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
+                        logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
                         executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size, lock)
+                        logging.debug(f"Submitted disk scan for {path}")
                         i += 1
 
             t.stop()
@@ -193,7 +197,9 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                 if sample_size != -1:
                     bytes_total = config.bytes_total
 
-            bytes_unique = min(len(config.fingerprints) * m * size, bytes_total)
+            logging.debug(f"Unique chunks: {len(config.fingerprints)}")
+            unique_chunks = set(config.fingerprints)
+            bytes_unique = min(len(unique_chunks) * m * size, bytes_total)
 
             if bytes_total:
                 if bytes_unique:
@@ -201,8 +207,8 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                     results['paths'] = list(paths)
                     time_taken = int(Timer.timers.mean("scan")) + 0.1
                     data_per_s = bytes_total / time_taken
-                    click.echo("Unique Chunks:\t{}".format(intcomma(len(config.fingerprints))))
-                    results["unique_chunks"] = intcomma(len(config.fingerprints))
+                    click.echo("Unique Chunks:\t{}".format(intcomma(len(unique_chunks))))
+                    results["unique_chunks"] = intcomma(len(unique_chunks))
                     click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
                     results["unique_data"] = naturalsize(bytes_unique, True)
                     click.echo("Data scanned:\t{}".format(naturalsize(bytes_total, True)))

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import threading
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
+#logging.basicConfig(level=logging.debug)
 
 from fastcdc.utils import DefaultHelp, supported_hashes
 
@@ -126,7 +126,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
             m = 1000    # 1 in m chunks are included in the sample
             x = random.randint(0, m - 1)    # random integer between 0 and m.
 
-        logging.debug(f"Sampling parameters: m={m}, x={x}")
+        #logging.debug(f"Sampling parameters: m={m}, x={x}")
 
         '''
         m and x together act as a filter and decide whether a chunk will be stored in the sample
@@ -164,8 +164,8 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                             dsize = int(d.size)
                             sizes.append(dsize)
                             bytes_total += dsize
-                logging.debug(f"Raw disk path: {path}")
-                logging.debug(f"Disk size: {sizes}")
+                #logging.debug(f"Raw disk path: {path}")
+                #logging.debug(f"Disk size: {sizes}")
 
             if not sizes or not bytes_total:
                 click.echo("Wrong path or incorrect type.")
@@ -179,16 +179,16 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
             if sample_size != -1:
                 bytes_total = sample_size
 
-            logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
+            #logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
 
             i = 0
             bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
             with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
-                        logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
+                        #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
                         executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size, lock)
-                        logging.debug(f"Submitted disk scan for {path}")
+                        #logging.debug(f"Submitted disk scan for {path}")
                         i += 1
 
             t.stop()
@@ -197,7 +197,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                 if sample_size != -1:
                     bytes_total = config.bytes_total
 
-            logging.debug(f"Unique chunks: {len(config.fingerprints)}")
+            #logging.debug(f"Unique chunks: {len(config.fingerprints)}")
             unique_chunks = set(config.fingerprints)
             bytes_unique = min(len(unique_chunks) * m * size, bytes_total)
 

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import threading
 import logging
 
-#logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 
 from fastcdc.utils import DefaultHelp, supported_hashes
 
@@ -126,7 +126,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
             m = 1000    # 1 in m chunks are included in the sample
             x = random.randint(0, m - 1)    # random integer between 0 and m.
 
-        #logging.debug(f"Sampling parameters: m={m}, x={x}")
+        logging.debug(f"Sampling parameters: m={m}, x={x}")
 
         '''
         m and x together act as a filter and decide whether a chunk will be stored in the sample
@@ -164,8 +164,8 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                             dsize = int(d.size)
                             sizes.append(dsize)
                             bytes_total += dsize
-                #logging.debug(f"Raw disk path: {path}")
-                #logging.debug(f"Disk size: {sizes}")
+                logging.debug(f"Raw disk path: {path}")
+                logging.debug(f"Disk size: {sizes}")
 
             if not sizes or not bytes_total:
                 click.echo("Wrong path or incorrect type.")
@@ -179,16 +179,16 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
             if sample_size != -1:
                 bytes_total = sample_size
 
-            #logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
+            logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
 
             i = 0
             bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
             with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
-                        #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
+                        logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
                         executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size, lock)
-                        #logging.debug(f"Submitted disk scan for {path}")
+                        logging.debug(f"Submitted disk scan for {path}")
                         i += 1
 
             t.stop()
@@ -197,7 +197,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                 if sample_size != -1:
                     bytes_total = config.bytes_total
 
-            #logging.debug(f"Unique chunks: {len(config.fingerprints)}")
+            logging.debug(f"Unique chunks: {len(config.fingerprints)}")
             unique_chunks = set(config.fingerprints)
             bytes_unique = min(len(unique_chunks) * m * size, bytes_total)
 

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -12,10 +12,15 @@ from tqdm import tqdm
 from humanize import intcomma, naturalsize, precisedelta
 from codetiming import Timer
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
+import logging
 
-import fastcdc
+logging.basicConfig(level=logging.DEBUG)
+
 from fastcdc.utils import DefaultHelp, supported_hashes
 
+# Create a lock for thread-safe access to shared resources
+lock = threading.Lock()
 
 def iter_files(path, recursive=False):
     if recursive:
@@ -41,17 +46,14 @@ def iter_files(path, recursive=False):
 @click.argument(
     "paths",
     type=click.Path(exists=True, file_okay=True, dir_okay=True, readable=False, resolve_path=True), nargs=-1,
-    #type=click.Path(exists=True, readable=False, resolve_path=True), nargs=-1,
-    required = True
+    required=True
 )
-
 @click.option(
     "-r", "--recursive/--non-recursive",
     help="Scan directory tree recursively",
     default=True,
     show_default=True
 )
-
 @click.option(
     "-s",
     "--size",
@@ -60,15 +62,13 @@ def iter_files(path, recursive=False):
     help="The size of the chunks in bytes",
     show_default=True,
 )
-
 @click.option(
     "-hf",
     "--hash-function",
     type=click.STRING,
-    default="xxh32",
+    default="sha256",
     show_default=True
 )
-
 @click.option(
     "-o",
     "--outpath",
@@ -76,7 +76,6 @@ def iter_files(path, recursive=False):
     type=click.Path(exists=True, file_okay=False, resolve_path=True),
     default=os.getcwd()
 )
-
 @click.option(
     "-t",
     "--max-threads",
@@ -85,27 +84,23 @@ def iter_files(path, recursive=False):
     default=16,
     show_default=True
 )
-
 @click.option(
     "-raw",
     help="To scan raw disk",
     is_flag=True,
     default=False,
 )
-
 @click.option(
     "--nosampling",
     help="Use this option to get more accurate results. But it uses more memory",
     is_flag=True,
     default=False
 )
-
 @click.option(
     "--sample-size",
     help="Size of the sample to be scanned (in GB)",
     default=-1
 )
-
 @click.option(
     "--isconfig",
     help="Given path is a path to config file",
@@ -113,203 +108,196 @@ def iter_files(path, recursive=False):
     default=False,
     show_default=True
 )
-
 def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosampling, sample_size, isconfig):
     """
     Scan and report duplication.
     """
-    click.echo("DCS Deduplication Estimation Tool\n")
-    
-    if isconfig:
-        config_file = open(paths[0])
-        paths = config_file.read().split('\n')
-
-    if nosampling:
-        m = 1
-        x = 0
-    else:
-        m = 1000    # 1 in m chunks are included in the sample
-        x = random.randint(0, m - 1)    # random integer between 0 and m.
-
-    '''
-    m and x together act as a filter and decide whether a chunk will be stored in the sample
-    '''
-
-    if sample_size != -1:
-        sample_size = sample_size  * 1024 * 1024 * 1024
-    
-    supported = supported_hashes()
-    hf = getattr(hashlib, hash_function)
-
-    path_count = len(paths) # number of input path
-    bytes_total = 0
-
-
-    if raw:
-        '''
-        For reading raw physical/logical disks
-        '''
-
-        click.echo("Scanning the disks...")
+    try:
+        click.echo("DCS Deduplication Estimation Tool\n")
         
-        sizes = []
-        
-        for path in paths:
-            try:
-                fd = os.open(path, os.O_RDONLY)
-                dsize = os.lseek(fd, 0, os.SEEK_END)
-                sizes.append(dsize)
-                bytes_total += dsize
-            except:
-                import wmi
-                for d in wmi.WMI().Win32_DiskDrive():
+        if isconfig:
+            config_file = open(paths[0])
+            paths = config_file.read().split('\n')
+
+        if nosampling:
+            m = 1
+            x = 0
+        else:
+            m = 1000    # 1 in m chunks are included in the sample
+            x = random.randint(0, m - 1)    # random integer between 0 and m.
+
+        '''
+        m and x together act as a filter and decide whether a chunk will be stored in the sample
+        '''
+        if sample_size != -1:
+            sample_size = sample_size * 1024 * 1024 * 1024
+
+        supported = supported_hashes()
+        hf = getattr(hashlib, hash_function)
+
+        path_count = len(paths) # number of input path
+        bytes_total = 0
+
+        if raw:
+            '''
+            For reading raw physical/logical disks
+            '''
+            click.echo("Scanning the disks...")
+            sizes = []
+            for path in paths:
+                try:
+                    fd = os.open(path, os.O_RDONLY)
+                    dsize = os.lseek(fd, 0, os.SEEK_END)
+                    sizes.append(dsize)
+                    bytes_total += dsize
+                except:
+                    import wmi
+                    for d in wmi.WMI().Win32_DiskDrive():
                         if d.DeviceID == path:
                             dsize = int(d.size)
                             sizes.append(dsize)
                             bytes_total += dsize
-                            
-                for d in wmi.WMI().Win32_LogicalDisk():
+                    for d in wmi.WMI().Win32_LogicalDisk():
                         if d.name == path[4:]:
                             dsize = int(d.size)
                             sizes.append(dsize)
                             bytes_total += dsize
-                            
-        if not sizes or not bytes_total:
-            click.echo("Wrong path or incorrect type.")
-            return
 
-        click.echo("Total size: {}\n".format(naturalsize(bytes_total, True)))
-            
-        t = Timer("scan", logger=None)
-        t.start()
+            if not sizes or not bytes_total:
+                click.echo("Wrong path or incorrect type.")
+                return
 
-        if sample_size != -1:
-            bytes_total = sample_size
+            click.echo("Total size: {}\n".format(naturalsize(bytes_total, True)))
 
-        i = 0
-        bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
-        with tqdm(total=bytes_total, desc = "Estimating dedup ratio", unit= " path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
-            # seperately process each disk
-            with ThreadPoolExecutor(max_workers=path_count) as executor:
-                for path in paths:
-                    executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size)
-                    i += 1
+            t = Timer("scan", logger=None)
+            t.start()
 
-        t.stop()
-
-        if sample_size != -1:
-            bytes_total = config.bytes_total
-        
-        bytes_unique = min(len(config.fingerprints) * m * size, bytes_total)
-        
-        if bytes_total:
-            if bytes_unique:
-                results = {}
-                results['paths'] = list(paths)
-                time_taken = int(Timer.timers.mean("scan")) + 0.1
-                data_per_s = bytes_total / time_taken
-                click.echo("Unique Chunks:\t{}".format(intcomma(len(config.fingerprints))))
-                results["unique_chunks"] = intcomma(len(config.fingerprints))
-                click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
-                results["unique_data"] = naturalsize(bytes_unique, True)
-                click.echo("Data scanned:\t{}".format(naturalsize(bytes_total, True)))
-                results["data_scanned"] = naturalsize(bytes_total, True)
-                click.echo("DeDupe Ratio:\t{:.2f}".format(bytes_total / bytes_unique))
-                results["dedup_ratio"] = round(bytes_total / bytes_unique, 2)
-                click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
-                results["throughput"] = str(naturalsize(data_per_s, True)) + "/s"
-                click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
-                
-                # Saving the output in a json file.
-                output = "DedupEstimationResult.txt"
-                with open(os.path.join(outpath,output), "w") as outfile:
-                    outfile.write(json.dumps(results, indent = 2))
-            else:
-                print("Very less unique data / High Duplication.\nUse --nosampling option.\nOr try running the tool as administrator")
-        else:
-            click.echo("No data.\n")
-
-    else:
-        '''
-        For files
-        '''
-
-        click.echo("Scanning the paths...")
-        
-        file_count = 0 # total number of files
-        files_to_scan = 0
-        bytes_sample = 0
-        
-        for path in paths:
-            for file in iter_files(path, recursive):
-                if sample_size != -1 and bytes_sample + file[1] <= sample_size:
-                    try:
-                        f = open(file[0], 'r')
-                        f.close()
-                        files_to_scan += 1
-                        bytes_sample += file[1]
-                    except:
-                        pass
-                bytes_total += file[1]
-                file_count += 1
-                click.echo("\rNumber of files found: {}".format(intcomma(file_count)), nl=False)
-        
-        click.echo("\nTotal size: {}".format(naturalsize(bytes_total, True)))
-        if sample_size == -1:
-            files_to_scan = file_count
-        else:
-            click.echo("Sample size: {}\n".format(naturalsize(sample_size, True)))
-        
-        t = Timer("scan", logger=None)
-        t.start()
-
-        bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [time elapsed: {elapsed}, time remaining: {remaining}]'
-        with tqdm(total=files_to_scan, desc = "Estimating dedup ratio", unit= " file", ascii=' #', bar_format=bar_format, leave=False) as pbar:
-            # seperately process files in each input path
-            with ThreadPoolExecutor(max_workers=path_count) as executor:
-                for path in paths:
-                    executor.submit(process_path, path, recursive, size, hf, m, x, max_threads, pbar, sample_size)
-
-        t.stop()
-
-        click.echo("\nFiles scanned: {}".format(str(config.files_scanned)))
-        
-        bytes_total = config.bytes_total
-        chunks_unique = min(len(config.fingerprints) * m, config.chunk_count)
-        dedup_ratio = config.chunk_count / chunks_unique
-        bytes_unique = int(bytes_total / dedup_ratio)
-        
-        if bytes_total:
-            if bytes_unique:
-                results = {}
-                results['paths'] = list(paths)
-                time_taken = int(Timer.timers.mean("scan")) + 0.1
-                data_per_s = bytes_total / time_taken
-                results["files"] = intcomma(file_count)
-                click.echo("Unique Chunks:\t{}".format(intcomma(chunks_unique)))
-                results["unique_chunks"] = intcomma(chunks_unique)
-                click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
-                results["unique_data"] = naturalsize(bytes_unique, True)
-                click.echo("Data scanned:\t{}".format(naturalsize(bytes_total, True)))
-                results["data_scanned"] = naturalsize(bytes_total, True)
-                click.echo("DeDupe Ratio:\t{:.2f}".format(dedup_ratio))
-                results["dedup_ratio"] = round(dedup_ratio, 2)
-                click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
-                results["throughput"] = str(naturalsize(data_per_s, True)) + "/s"
-                click.echo("Files Skipped:\t{}".format(intcomma(config.files_skipped)))
-                results["files_skippped"] = config.files_skipped
-                click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
-                
-                # Saving the output in a json file.
-                output = "DedupEstimationResult.txt"
-                with open(os.path.join(outpath,output), "w") as outfile:
-                    outfile.write(json.dumps(results, indent = 2))
-            else:
-                click.echo("Very less unique data / High Duplication.\nUse --nosampling option.\nOr try running the tool as administrator if admin privileges are required to read the files")
             if sample_size != -1:
-                click.echo("\nIf the file sizes exceed the sample size, the data scanned will be less than the sample size. To scan more data, increase the sample size")
+                bytes_total = sample_size
+
+            i = 0
+            bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
+            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
+                with ThreadPoolExecutor(max_workers=path_count) as executor:
+                    for path in paths:
+                        executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size)
+                        i += 1
+
+            t.stop()
+
+            with lock:
+                if sample_size != -1:
+                    bytes_total = config.bytes_total
+
+            bytes_unique = min(len(config.fingerprints) * m * size, bytes_total)
+
+            if bytes_total:
+                if bytes_unique:
+                    results = {}
+                    results['paths'] = list(paths)
+                    time_taken = int(Timer.timers.mean("scan")) + 0.1
+                    data_per_s = bytes_total / time_taken
+                    click.echo("Unique Chunks:\t{}".format(intcomma(len(config.fingerprints))))
+                    results["unique_chunks"] = intcomma(len(config.fingerprints))
+                    click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
+                    results["unique_data"] = naturalsize(bytes_unique, True)
+                    click.echo("Data scanned:\t{}".format(naturalsize(bytes_total, True)))
+                    results["data_scanned"] = naturalsize(bytes_total, True)
+                    click.echo("DeDupe Ratio:\t{:.2f}".format(bytes_total / bytes_unique))
+                    results["dedup_ratio"] = round(bytes_total / bytes_unique, 2)
+                    click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
+                    results["throughput"] = str(naturalsize(data_per_s, True)) + "/s"
+                    click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
+
+                    # Saving the output in a json file.
+                    output = "DedupEstimationResult.txt"
+                    with open(os.path.join(outpath, output), "w") as outfile:
+                        outfile.write(json.dumps(results, indent=2))
+                else:
+                    print("Very less unique data / High Duplication.\nUse --nosampling option.\nOr try running the tool as administrator")
+            else:
+                click.echo("No data.\n")
+
         else:
-            click.echo("No data or cannot access the files.\n")
+            click.echo("Scanning the paths...")
+            file_count = 0 # total number of files
+            files_to_scan = 0
+            bytes_sample = 0
+
+            for path in paths:
+                for file in iter_files(path, recursive):
+                    if sample_size != -1 and bytes_sample + file[1] <= sample_size:
+                        try:
+                            f = open(file[0], 'r')
+                            f.close()
+                            files_to_scan += 1
+                            bytes_sample += file[1]
+                        except:
+                            pass
+                    with lock:
+                        bytes_total += file[1]
+                        file_count += 1
+                    click.echo("\rNumber of files found: {}".format(intcomma(file_count)), nl=False)
+
+            click.echo("\nTotal size: {}".format(naturalsize(bytes_total, True)))
+            if sample_size == -1:
+                files_to_scan = file_count
+            else:
+                click.echo("Sample size: {}\n".format(naturalsize(sample_size, True)))
+
+            t = Timer("scan", logger=None)
+            t.start()
+
+            bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [time elapsed: {elapsed}, time remaining: {remaining}]'
+            with tqdm(total=files_to_scan, desc="Estimating dedup ratio", unit=" file", ascii=' #', bar_format=bar_format, leave=False) as pbar:
+                # seperately process files in each input path
+                with ThreadPoolExecutor(max_workers=path_count) as executor:
+                    for path in paths:
+                        executor.submit(process_path, path, recursive, size, hf, m, x, max_threads, pbar, sample_size)
+
+            t.stop()
+
+            with lock:
+                click.echo("\nFiles scanned: {}".format(str(config.files_scanned)))
+                bytes_total = config.bytes_total
+                chunks_unique = min(len(config.fingerprints) * m, config.chunk_count)
+                dedup_ratio = config.chunk_count / chunks_unique
+                bytes_unique = int(bytes_total / dedup_ratio)
+
+            if bytes_total:
+                if bytes_unique:
+                    results = {}
+                    results['paths'] = list(paths)
+                    time_taken = int(Timer.timers.mean("scan")) + 0.1
+                    data_per_s = bytes_total / time_taken
+                    results["files"] = intcomma(file_count)
+                    click.echo("Unique Chunks:\t{}".format(intcomma(chunks_unique)))
+                    results["unique_chunks"] = intcomma(chunks_unique)
+                    click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
+                    results["unique_data"] = naturalsize(bytes_unique, True)
+                    click.echo("Data scanned:\t{}".format(naturalsize(bytes_total, True)))
+                    results["data_scanned"] = naturalsize(bytes_total, True)
+                    click.echo("DeDupe Ratio:\t{:.2f}".format(dedup_ratio))
+                    results["dedup_ratio"] = round(dedup_ratio, 2)
+                    click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
+                    results["throughput"] = str(naturalsize(data_per_s, True)) + "/s"
+                    click.echo("Files Skipped:\t{}".format(intcomma(config.files_skipped)))
+                    results["files_skippped"] = config.files_skipped
+                    click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
+
+                    output = "DedupEstimationResult.txt"
+                    with open(os.path.join(outpath, output), "w") as outfile:
+                        outfile.write(json.dumps(results, indent=2))
+                else:
+                    click.echo("Very less unique data / High Duplication.\nUse --nosampling option.\nOr try running the tool as administrator if admin privileges are required to read the files")
+                if sample_size != -1:
+                    click.echo("\nIf the file sizes exceed the sample size, the data scanned will be less than the sample size. To scan more data, increase the sample size")
+            else:
+                click.echo("No data or cannot access the files.\n")
+        return 0
+    except Exception as e:
+        logging.error(f"An error occurred: {e}")
+        return 2
 
 
 if __name__ == "__main__":

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import threading
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
+#logging.basicConfig(level=logging.DEBUG)
 
 from fastcdc.utils import DefaultHelp, supported_hashes
 
@@ -126,7 +126,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
             m = 1000    # 1 in m chunks are included in the sample
             x = random.randint(0, m - 1)    # random integer between 0 and m.
 
-        logging.debug(f"Sampling parameters: m={m}, x={x}")
+        #logging.debug(f"Sampling parameters: m={m}, x={x}")
 
         '''
         m and x together act as a filter and decide whether a chunk will be stored in the sample
@@ -164,8 +164,8 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                             dsize = int(d.size)
                             sizes.append(dsize)
                             bytes_total += dsize
-                logging.debug(f"Raw disk path: {path}")
-                logging.debug(f"Disk size: {sizes}")
+                #logging.debug(f"Raw disk path: {path}")
+                #logging.debug(f"Disk size: {sizes}")
 
             if not sizes or not bytes_total:
                 click.echo("Wrong path or incorrect type.")
@@ -179,16 +179,16 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
             if sample_size != -1:
                 bytes_total = sample_size
 
-            logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
+            #logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
 
             i = 0
             bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
             with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
-                        logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
+                        #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
                         executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size, lock)
-                        logging.debug(f"Submitted disk scan for {path}")
+                        #logging.debug(f"Submitted disk scan for {path}")
                         i += 1
 
             t.stop()
@@ -197,7 +197,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, nosam
                 if sample_size != -1:
                     bytes_total = config.bytes_total
 
-            logging.debug(f"Unique chunks: {len(config.fingerprints)}")
+            #logging.debug(f"Unique chunks: {len(config.fingerprints)}")
             unique_chunks = set(config.fingerprints)
             bytes_unique = min(len(unique_chunks) * m * size, bytes_total)
 

--- a/Tools/DedupEstimationTool/config.py
+++ b/Tools/DedupEstimationTool/config.py
@@ -1,11 +1,25 @@
+from collections import defaultdict
+
 def init():
     global fingerprints
     global files_skipped
     global bytes_total
     global files_scanned
     global chunk_count
+    global last_offsets
+    global zero_chunks_skipped
+    global zero_bytes_skipped
+    global last_offsets_real
+    global last_offsets_zero
+
+    last_offsets = defaultdict(int)
     fingerprints = set()
     files_skipped = 0
     bytes_total = 0
     files_scanned = 0
     chunk_count = 0
+
+    zero_chunks_skipped = 0
+    zero_bytes_skipped = 0
+    last_offsets_zero = defaultdict(int)
+    last_offsets_real = defaultdict(int)

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -5,13 +5,17 @@ import logging
 import sys
 import os
 import traceback
+from humanize import naturalsize
+
+from collections import defaultdict
 
 READ_BLOCK_SIZE = 1024 * 1024           # 1MB read chunks
 FASTCDC_WINDOW_SIZE = 16 * 1024 * 1024  # 16MB window for CDC
 OVERLAP_SIZE = 2 * 1024 * 1024          # 2MB overlap for chunk boundary safety
-#logging.basicConfig(level=logging.debug)
 
-def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, lock):
+logging.basicConfig(level=logging.DEBUG)
+
+def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, skip_zeroes, lock):
     """
     Orchestrates the parallel processing of a disk by dividing it based on the number of threads
     and assigning each part to a thread for processing.
@@ -51,7 +55,7 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
                             m,
                             x,
                             pbar,
-                            sample_size,
+                            skip_zeroes,
                             lock
                         )
                     )
@@ -65,8 +69,13 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
             except Exception as e:
                 logging.error(f"Error in thread execution: {e}")
 
-def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_function, m, x, pbar, sample_size, lock):
+def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_function, m, x, pbar, skip_zeroes, lock):
     handle = None
+    with lock:
+        if disk not in config.last_offsets_real:
+            config.last_offsets_real[disk] = 0
+        if disk not in config.last_offsets_zero:
+            config.last_offsets_zero[disk] = 0
     try:
         flags = os.O_RDONLY
         if sys.platform == 'win32':
@@ -83,11 +92,26 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
             try:
                 to_read = min(READ_BLOCK_SIZE, total_size - processed_bytes)
                 chunk = os.read(handle, to_read)
+                #logging.debug(f"Raw read of {to_read} bytes at offset {start_offset + processed_bytes}")
                 if not chunk:
-                    break  # Reached EOF or failed to read
-                buffer.extend(chunk)
-                processed_bytes += len(chunk)
-                pbar.update(len(chunk))
+                    break
+                # If skip-zeroes is on and full buffer is zero, skip ahead
+                if skip_zeroes and chunk.count(0) == len(chunk):
+                    with lock:
+                        config.zero_chunks_skipped += 1
+                        config.zero_bytes_skipped += len(chunk)
+                        config.last_offsets_zero[disk] = start_offset + processed_bytes + len(chunk)
+                        pbar.update(len(chunk))
+
+                    #logging.debug(f"[ZERO SKIP] Offset: {start_offset + processed_bytes}, Size: {len(chunk)}")
+                    processed_bytes += len(chunk)
+                    continue
+                else:
+                    buffer.extend(chunk)
+                    processed_bytes += len(chunk)
+                    with lock:
+                        pbar.update(len(chunk))
+                    #logging.debug(f"[READ] Offset: {start_offset + processed_bytes - len(chunk)}, Size: {len(chunk)}")
             except Exception as e:
                 logging.error(f"Error reading at offset {start_offset + processed_bytes}: {e}")
                 logging.error(traceback.format_exc())
@@ -95,37 +119,44 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
 
             # Process CDC when buffer is large enough
             if len(buffer) >= FASTCDC_WINDOW_SIZE:
+                window = bytes(buffer[:FASTCDC_WINDOW_SIZE])
                 try:
-                    window = bytes(buffer[:FASTCDC_WINDOW_SIZE])
                     chunker = fastcdc.fastcdc(window, chunksize, chunksize, chunksize, hf=hash_function)
 
                     for c in chunker:
-                        try:
-                            h = int(c.hash, 16)
-                            if h % m == x:
-                                with lock:
-                                    config.fingerprints.add(h)
-                        except Exception as e:
-                            logging.error(f"Error processing chunk hash: {e}")
-                except Exception as e:
-                    logging.error(f"FastCDC failed on buffer: {e}")
-                    logging.error(traceback.format_exc())
-
-                # Slide buffer forward, keeping overlap
-                buffer = buffer[FASTCDC_WINDOW_SIZE - OVERLAP_SIZE:]
-
-        # Process final leftover buffer
-        if buffer:
-            try:
-                chunker = fastcdc.fastcdc(bytes(buffer), chunksize, chunksize, chunksize, hf=hash_function)
-                for c in chunker:
-                    try:
+                        abs_offset = start_offset + processed_bytes - len(buffer) + c.offset
                         h = int(c.hash, 16)
                         if h % m == x:
                             with lock:
                                 config.fingerprints.add(h)
-                    except Exception as e:
-                        logging.error(f"Error processing final chunk hash: {e}")
+                                config.chunk_count += 1
+                                if abs_offset < config.last_offsets_real[disk]:
+                                    pass  # Overlaps with previous chunk, skip
+                                else:
+                                    config.bytes_total += c.length
+                                    config.last_offsets_real[disk] = abs_offset + c.length
+                except Exception as e:
+                    logging.error(f"FastCDC failed on buffer: {e}")
+                    logging.error(traceback.format_exc())
+                finally:
+                    # Always trim buffer to maintain progress
+                    buffer = buffer[FASTCDC_WINDOW_SIZE - OVERLAP_SIZE:]
+
+        if buffer:  # Process final leftover buffer
+            try:
+                chunker = fastcdc.fastcdc(bytes(buffer), chunksize, chunksize, chunksize, hf=hash_function)
+                for c in chunker:
+                    abs_offset = start_offset + total_size - len(buffer) + c.offset
+                    h = int(c.hash, 16)
+                    if h % m == x:
+                            with lock:
+                                config.fingerprints.add(h)
+                                config.chunk_count += 1
+                                if abs_offset < config.last_offsets_real[disk]:
+                                    pass  # Overlaps with previous chunk, skip
+                                else:
+                                    config.bytes_total += c.length
+                                    config.last_offsets_real[disk] = abs_offset + c.length
             except Exception as e:
                 logging.error(f"Final FastCDC failed: {e}")
                 logging.error(traceback.format_exc())
@@ -133,17 +164,19 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
         # Stats update
         with lock:
             config.files_scanned += 1
-            if sample_size == -1:
-                config.bytes_total += processed_bytes
-            config.chunk_count += processed_bytes // chunksize
-            if processed_bytes % chunksize != 0:
-                config.chunk_count += 1
-            config.files_skipped += 1
+            '''logging.debug(
+                f"[STATS] Disk: {disk} | Bytes Total: {config.bytes_total} | "
+                f"Chunks: {config.chunk_count} | Unique: {len(config.fingerprints)} | "
+                f"Zero Skipped: {config.zero_chunks_skipped} ({naturalsize(config.zero_bytes_skipped)})"
+            )'''
 
     except Exception as e:
         logging.error(f"Failed to process raw disk {disk}: {repr(e)}")
         logging.error(traceback.format_exc())
+        with lock:
+            config.files_skipped += 1
 
     finally:
+        #logging.debug(f"Finished processing {disk} from {start_offset} to {end_offset}, now config.bytes_total={config.bytes_total}, config.chunk_count={config.chunk_count}, config.zero_chunks_skipped={config.zero_chunks_skipped}, config.zero_bytes_skipped={config.zero_bytes_skipped}")
         if handle is not None:
             os.close(handle)

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -1,91 +1,121 @@
 import config
 import fastcdc
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import threading
+from io import BytesIO
+
+logging.basicConfig(level=logging.DEBUG)
 
 def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, lock):
     """
-    Creates a threadpool to process the data in the disk.
+    Orchestrates the parallel processing of a disk by dividing it based on the number of threads
+    and assigning each part to a thread for processing.
     """
     logging.debug(f"Starting process_disk for {disk}")
+    print("Starting process_disk for", disk)
+
+    # Adjust disk size based on sample_size
     if sample_size != -1:
-        disk_size = sample_size
-    
-    disk_size -= disk_size % 512
-    size_per_thread = (disk_size // threads) + 1
-    size_per_thread -= size_per_thread % 512
-    
-    iters = (size_per_thread // chunksize) + 1
+        disk_size = min(disk_size, sample_size)
+    disk_size -= disk_size % chunksize  # Ensure disk_size is a multiple of chunksize
+
+    # Calculate the size of each thread's workload
+    size_per_thread = (disk_size + threads - 1) // threads
+    size_per_thread -= size_per_thread % chunksize  # Ensure size_per_thread is a multiple of chunksize
+    iters = size_per_thread // chunksize  # Calculate iterations per thread
+
     logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}, Iterations per thread: {iters}")
 
-    offset = 0
-    with ThreadPoolExecutor(max_workers=threads) as executor:
-        for i in range(threads):
-            if sample_size != -1 and config.bytes_total >= sample_size:
-                logging.debug(f"Sample size reached: {config.bytes_total} >= {sample_size}")
-                break
-            try:
-                handle = open(disk, "rb")
-                handle.seek(offset, 0)
-                
-                # Adjust size_per_thread for the last thread
-                if i == threads - 1:
-                    size_per_thread = disk_size - offset
-                
-                logging.debug(f"Submitting thread {i} with offset {offset} and size {size_per_thread}")
-                executor.submit(
-                    process_partial_disk,
-                    handle,
-                    iters,
-                    chunksize,
-                    hash_function,
-                    m,
-                    x,
-                    threads,
-                    pbar,
-                    size_per_thread,
-                    lock  # Pass the lock object
-                )
-                offset += size_per_thread
-                config.bytes_total += size_per_thread
-            except Exception as e:
-                logging.error(f"Error submitting thread {i}: {e}")
-
-def process_partial_disk(handle, iters, chunksize, hash_function, m, x, threads, pbar, size_per_thread, lock):
-    """
-    Processes a portion of the disk in chunks.
-    """
+    # Open the file handle
     try:
-        logging.debug(f"Thread {threading.current_thread().name} started processing with size {size_per_thread}")
-        logging.debug(f"fastcdc.fastcdc initializing now with chunksize {chunksize} and hash_function {hash_function}")
-        chunker = fastcdc.fastcdc(handle, chunksize, chunksize, chunksize, hf=hash_function)
-        logging.debug(f"Chunker initialized successfully for thread {threading.current_thread().name}")
+        with open(disk, "rb") as handle:
+            logging.debug(f"Opened raw disk {disk} successfully")
+            # Use ThreadPoolExecutor to process parts in parallel
+            with ThreadPoolExecutor(max_workers=threads) as executor:
+                futures = []
+                for i in range(threads):
+                    start_offset = i * size_per_thread
+                    end_offset = min((i + 1) * size_per_thread, disk_size)
+
+                    if start_offset < disk_size:
+                        logging.debug(f"Submitting thread {i} with start_offset {start_offset} and end_offset {end_offset}")
+                        try:
+                            futures.append(
+                                executor.submit(
+                                    process_partial_disk,
+                                    disk,
+                                    start_offset,
+                                    end_offset,
+                                    chunksize,
+                                    hash_function,
+                                    m,
+                                    x,
+                                    pbar,
+                                    sample_size,
+                                    lock
+                                )
+                            )
+                        except Exception as e:
+                            logging.error(f"Error submitting thread {i}: {e}")
+
+                # Wait for all threads to complete
+                for future in futures:
+                    try:
+                        future.result()
+                    except Exception as e:
+                        logging.error(f"Error in thread execution: {e}")
     except Exception as e:
-        clickl.echo(str(e))
-        logging.error(f"Error initializing chunker: {e}")
-        with lock:
-            config.files_skipped += 1  # Increment skipped files count
+        logging.error(f"Failed to open raw disk {disk}: {e}")
         return
 
-    iter_count = 0
-    for chunk in chunker:
-        try:
-            logging.debug(f"Processing chunk with hash {chunk.hash}")
-            if int(chunk.hash, 16) % m == x:
-                with lock:
-                    config.fingerprints.add(int(chunk.hash, 16))
-                    logging.debug(f"Added chunk hash {chunk.hash} to fingerprints")
-        except Exception as e:
-            logging.error(f"Error processing chunk: {e}")
+def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_function, m, x, pbar, sample_size, lock):
+    """
+    Processes a portion of the disk assigned to a thread. It reads the disk in chunks, computes a hash for each chunk,
+    and performs deduplication or filtering based on the hash.
+    """
+    
+    
+    with open(disk, "rb") as handle:
+        logging.debug(f"Thread {threading.current_thread().name} started processing from offset {start_offset} to {end_offset}")
+        handle.seek(start_offset)
+        processed = 0  # Bytes processed
 
-        iter_count += 1
-        if iter_count >= iters:
-            break
 
-    with lock:
-        config.bytes_total += iter_count * chunksize
-    logging.debug(f"Thread {threading.current_thread().name} processed {iter_count} chunks.")
+        # Processing loop
+        while processed < (end_offset - start_offset):
+            part_disk_size = end_offset - start_offset
+            part_disk = handle.read(part_disk_size)
+            if not part_disk:
+                break  # EOF or partial read
 
+            try:
+                chunker = fastcdc.fastcdc(part_disk, chunksize, chunksize, chunksize, hf=hash_function)
+
+                for chunk in chunker:
+                    if int(chunk.hash, 16) % m == x:
+                        # The chunk passes the filter. So add it to the fingerprints
+                        with lock:
+                            config.fingerprints.add(int(chunk.hash, 16))
+            except Exception as e:
+                logging.error(f"Error processing chunk: {e}")
+
+            # Update the progress bar and increment processed bytes
+            with lock:
+                config.files_scanned += 1
+                if sample_size == -1:
+                    config.bytes_total += part_disk_size
+
+                config.chunk_count += part_disk_size // chunksize
+                if part_disk_size % chunksize != 0:
+                    config.chunk_count += 1
+                #pbar.update(len(chunk))
+
+            processed += len(part_disk)
+            iter_count += 1
+            pbar.update(len(part_disk))
+
+        with lock:
+            config.files_skipped += 1
 
 

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -2,9 +2,10 @@ import config
 import fastcdc
 from concurrent.futures import ThreadPoolExecutor
 import logging
-import threading
-from io import BytesIO
+import sys
+import os
 
+READ_BLOCK_SIZE = 1024 * 1024  # 1 MiB per read
 #logging.basicConfig(level=logging.DEBUG)
 
 def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, lock):
@@ -12,7 +13,7 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
     Orchestrates the parallel processing of a disk by dividing it based on the number of threads
     and assigning each part to a thread for processing.
     """
-    #logging.debug(f"Starting process_disk for {disk}")
+    logging.debug(f"Starting process_disk for {disk}")
     #print("Starting process_disk for", disk)
 
     # Adjust disk size based on sample_size
@@ -23,99 +24,105 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
     # Calculate the size of each thread's workload
     size_per_thread = (disk_size + threads - 1) // threads
     size_per_thread -= size_per_thread % chunksize  # Ensure size_per_thread is a multiple of chunksize
-    iters = size_per_thread // chunksize  # Calculate iterations per thread
+    
+    logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}")
 
-    #logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}, Iterations per thread: {iters}")
+    # Use ThreadPoolExecutor to process parts in parallel
+    with ThreadPoolExecutor(max_workers=threads) as executor:
+        futures = []
+        for i in range(threads):
+            start_offset = i * size_per_thread
+            end_offset = min((i + 1) * size_per_thread, disk_size)
 
-    # Open the file handle
-    try:
-        with open(disk, "rb") as handle:
-            #logging.debug(f"Opened raw disk {disk} successfully")
-            # Use ThreadPoolExecutor to process parts in parallel
-            with ThreadPoolExecutor(max_workers=threads) as executor:
-                futures = []
-                for i in range(threads):
-                    start_offset = i * size_per_thread
-                    end_offset = min((i + 1) * size_per_thread, disk_size)
+            if start_offset < disk_size:
+                logging.debug(f"Submitting thread {i} with start_offset {start_offset} and end_offset {end_offset}")
+                try:
+                    futures.append(
+                        executor.submit(
+                            process_partial_disk,
+                            disk,
+                            start_offset,
+                            end_offset,
+                            chunksize,
+                            hash_function,
+                            m,
+                            x,
+                            pbar,
+                            sample_size,
+                            lock
+                        )
+                    )
+                except Exception as e:
+                    logging.error(f"Error submitting thread {i}: {e}")
 
-                    if start_offset < disk_size:
-                        #logging.debug(f"Submitting thread {i} with start_offset {start_offset} and end_offset {end_offset}")
-                        try:
-                            futures.append(
-                                executor.submit(
-                                    process_partial_disk,
-                                    disk,
-                                    start_offset,
-                                    end_offset,
-                                    chunksize,
-                                    hash_function,
-                                    m,
-                                    x,
-                                    pbar,
-                                    sample_size,
-                                    lock
-                                )
-                            )
-                        except Exception as e:
-                            logging.error(f"Error submitting thread {i}: {e}")
+        # Wait for all threads to complete
+        for future in futures:
+            try:
+                future.result()
+            except Exception as e:
+                logging.error(f"Error in thread execution: {e}")
 
-                # Wait for all threads to complete
-                for future in futures:
-                    try:
-                        future.result()
-                    except Exception as e:
-                        logging.error(f"Error in thread execution: {e}")
-    except Exception as e:
-        logging.error(f"Failed to open raw disk {disk}: {e}")
-        return
+def read_large_range(handle, start_offset, total_bytes):
+    os.lseek(handle, start_offset, os.SEEK_SET)
+
+    data = bytearray()
+    bytes_left = total_bytes
+
+    while bytes_left > 0:
+        read_size = min(READ_BLOCK_SIZE, bytes_left)
+        chunk = os.read(handle, read_size)
+        if not chunk:
+            break
+        data.extend(chunk)
+        bytes_left -= len(chunk)
+
+    return bytes(data)
+
 
 def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_function, m, x, pbar, sample_size, lock):
-    """
-    Processes a portion of the disk assigned to a thread. It reads the disk in chunks, computes a hash for each chunk,
-    and performs deduplication or filtering based on the hash.
-    """
-    
-    
-    with open(disk, "rb") as handle:
-        #logging.debug(f"Thread {threading.current_thread().name} started processing from offset {start_offset} to {end_offset}")
-        handle.seek(start_offset)
-        processed = 0  # Bytes processed
+    handle = None
+    try:
+        flags = os.O_RDONLY
+        if sys.platform == 'win32':
+            flags |= os.O_BINARY
 
+        handle = os.open(disk, flags)
 
-        # Processing loop
-        while processed < (end_offset - start_offset):
-            part_disk_size = end_offset - start_offset
-            part_disk = handle.read(part_disk_size)
-            if not part_disk:
-                break  # EOF or partial read
+        # Read disk region in safe blocks
+        total_size = end_offset - start_offset
+        part_data = read_large_range(handle, start_offset, total_size)
 
-            try:
-                chunker = fastcdc.fastcdc(part_disk, chunksize, chunksize, chunksize, hf=hash_function)
+        # Apply FastCDC
+        try:
+            chunker = fastcdc.fastcdc(part_data, chunksize, chunksize, chunksize, hf=hash_function)
 
-                for chunk in chunker:
-                    if int(chunk.hash, 16) % m == x:
-                        # The chunk passes the filter. So add it to the fingerprints
-                        with lock:
-                            config.fingerprints.add(int(chunk.hash, 16))
-            except Exception as e:
-                logging.error(f"Error processing chunk: {e}")
+            for chunk in chunker:
+                if int(chunk.hash, 16) % m == x:
+                    with lock:
+                        config.fingerprints.add(int(chunk.hash, 16))
 
-            # Update the progress bar and increment processed bytes
-            with lock:
-                config.files_scanned += 1
-                if sample_size == -1:
-                    config.bytes_total += part_disk_size
+        except Exception as e:
+            logging.error(f"Error processing chunk: {e}")
 
-                config.chunk_count += part_disk_size // chunksize
-                if part_disk_size % chunksize != 0:
-                    config.chunk_count += 1
-                #pbar.update(len(chunk))
+        # Update stats
+        with lock:
+            config.files_scanned += 1
+            if sample_size == -1:
+                config.bytes_total += len(part_data)
 
-            processed += len(part_disk)
-            iter_count += 1
-            pbar.update(len(part_disk))
+            config.chunk_count += len(part_data) // chunksize
+            if len(part_data) % chunksize != 0:
+                config.chunk_count += 1
+
+        pbar.update(len(part_data))
 
         with lock:
             config.files_skipped += 1
 
+    except Exception as e:
+        logging.error(f"Failed to process raw disk {disk}: {e}")
+
+    finally:
+        if handle is not None:
+            os.close(handle)
 

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -2,11 +2,13 @@ import config
 import fastcdc
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import logging
+import threading
 
-def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size):
+def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, lock):
     """
     Creates a threadpool to process the data in the disk.
     """
+    logging.debug(f"Starting process_disk for {disk}")
     if sample_size != -1:
         disk_size = sample_size
     
@@ -15,53 +17,72 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
     size_per_thread -= size_per_thread % 512
     
     iters = (size_per_thread // chunksize) + 1
+    logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}, Iterations per thread: {iters}")
 
     offset = 0
     with ThreadPoolExecutor(max_workers=threads) as executor:
         for i in range(threads):
             if sample_size != -1 and config.bytes_total >= sample_size:
+                logging.debug(f"Sample size reached: {config.bytes_total} >= {sample_size}")
                 break
-            handle = open(disk, "rb")
-            handle.seek(offset, 0)
-            
-            # Adjust size_per_thread for the last thread
-            if i == threads - 1:
-                size_per_thread = disk_size - offset
-            
-            logging.debug(f"Submitting thread {i} with offset {offset} and size {size_per_thread}")
-            executor.submit(process_partial_disk, handle, iters, chunksize, hash_function, m, x, threads, pbar, size_per_thread)
-            offset += size_per_thread
-            config.bytes_total += size_per_thread
+            try:
+                handle = open(disk, "rb")
+                handle.seek(offset, 0)
+                
+                # Adjust size_per_thread for the last thread
+                if i == threads - 1:
+                    size_per_thread = disk_size - offset
+                
+                logging.debug(f"Submitting thread {i} with offset {offset} and size {size_per_thread}")
+                executor.submit(
+                    process_partial_disk,
+                    handle,
+                    iters,
+                    chunksize,
+                    hash_function,
+                    m,
+                    x,
+                    threads,
+                    pbar,
+                    size_per_thread,
+                    lock  # Pass the lock object
+                )
+                offset += size_per_thread
+                config.bytes_total += size_per_thread
+            except Exception as e:
+                logging.error(f"Error submitting thread {i}: {e}")
 
-def process_partial_disk(handle, iters, chunksize, hash_function, m, x, threads, pbar, size_per_thread):
+def process_partial_disk(handle, iters, chunksize, hash_function, m, x, threads, pbar, size_per_thread, lock):
+    """
+    Processes a portion of the disk in chunks.
+    """
     try:
+        logging.debug(f"Thread {threading.current_thread().name} started processing with size {size_per_thread}")
+        logging.debug(f"fastcdc.fastcdc initializing now with chunksize {chunksize} and hash_function {hash_function}")
         chunker = fastcdc.fastcdc(handle, chunksize, chunksize, chunksize, hf=hash_function)
+        logging.debug(f"Chunker initialized successfully for thread {threading.current_thread().name}")
     except Exception as e:
         clickl.echo(str(e))
+        logging.error(f"Error initializing chunker: {e}")
         with lock:
             config.files_skipped += 1  # Increment skipped files count
-        logging.error(f"Error processing disk: {e}")
         return
 
-    k = 256 * 64 // threads
-    
     iter_count = 0
-    iters_by_k = iters // k
-    i = 1
     for chunk in chunker:
-        if int(chunk.hash, 16) % m == x:
-            # Safely add the chunk hash to the fingerprints
-            with lock:
-                config.fingerprints.add(int(chunk.hash, 16))
-        if iter_count == iters_by_k * i:
-            with lock:
-                pbar.update(iters_by_k * chunksize)
-            i += 1
+        try:
+            logging.debug(f"Processing chunk with hash {chunk.hash}")
+            if int(chunk.hash, 16) % m == x:
+                with lock:
+                    config.fingerprints.add(int(chunk.hash, 16))
+                    logging.debug(f"Added chunk hash {chunk.hash} to fingerprints")
+        except Exception as e:
+            logging.error(f"Error processing chunk: {e}")
+
+        iter_count += 1
         if iter_count >= iters:
             break
-        iter_count += 1
 
-    # Safely update the total bytes processed
     with lock:
         config.bytes_total += iter_count * chunksize
     logging.debug(f"Thread {threading.current_thread().name} processed {iter_count} chunks.")

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -5,15 +5,15 @@ import logging
 import threading
 from io import BytesIO
 
-logging.basicConfig(level=logging.DEBUG)
+#logging.basicConfig(level=logging.DEBUG)
 
 def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, lock):
     """
     Orchestrates the parallel processing of a disk by dividing it based on the number of threads
     and assigning each part to a thread for processing.
     """
-    logging.debug(f"Starting process_disk for {disk}")
-    print("Starting process_disk for", disk)
+    #logging.debug(f"Starting process_disk for {disk}")
+    #print("Starting process_disk for", disk)
 
     # Adjust disk size based on sample_size
     if sample_size != -1:
@@ -25,12 +25,12 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
     size_per_thread -= size_per_thread % chunksize  # Ensure size_per_thread is a multiple of chunksize
     iters = size_per_thread // chunksize  # Calculate iterations per thread
 
-    logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}, Iterations per thread: {iters}")
+    #logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}, Iterations per thread: {iters}")
 
     # Open the file handle
     try:
         with open(disk, "rb") as handle:
-            logging.debug(f"Opened raw disk {disk} successfully")
+            #logging.debug(f"Opened raw disk {disk} successfully")
             # Use ThreadPoolExecutor to process parts in parallel
             with ThreadPoolExecutor(max_workers=threads) as executor:
                 futures = []
@@ -39,7 +39,7 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
                     end_offset = min((i + 1) * size_per_thread, disk_size)
 
                     if start_offset < disk_size:
-                        logging.debug(f"Submitting thread {i} with start_offset {start_offset} and end_offset {end_offset}")
+                        #logging.debug(f"Submitting thread {i} with start_offset {start_offset} and end_offset {end_offset}")
                         try:
                             futures.append(
                                 executor.submit(
@@ -77,7 +77,7 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
     
     
     with open(disk, "rb") as handle:
-        logging.debug(f"Thread {threading.current_thread().name} started processing from offset {start_offset} to {end_offset}")
+        #logging.debug(f"Thread {threading.current_thread().name} started processing from offset {start_offset} to {end_offset}")
         handle.seek(start_offset)
         processed = 0  # Bytes processed
 

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -9,14 +9,14 @@ import traceback
 READ_BLOCK_SIZE = 1024 * 1024           # 1MB read chunks
 FASTCDC_WINDOW_SIZE = 16 * 1024 * 1024  # 16MB window for CDC
 OVERLAP_SIZE = 2 * 1024 * 1024          # 2MB overlap for chunk boundary safety
-#logging.basicConfig(level=logging.DEBUG)
+#logging.basicConfig(level=logging.debug)
 
 def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, lock):
     """
     Orchestrates the parallel processing of a disk by dividing it based on the number of threads
     and assigning each part to a thread for processing.
     """
-    logging.debug(f"Starting process_disk for {disk}")
+    #logging.debug(f"Starting process_disk for {disk}")
     #print("Starting process_disk for", disk)
 
     # Adjust disk size based on sample_size
@@ -28,7 +28,7 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
     size_per_thread = (disk_size + threads - 1) // threads
     size_per_thread -= size_per_thread % chunksize  # Ensure size_per_thread is a multiple of chunksize
     
-    logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}")
+    #logging.debug(f"Disk size: {disk_size}, Size per thread: {size_per_thread}")
 
     # Use ThreadPoolExecutor to process parts in parallel
     with ThreadPoolExecutor(max_workers=threads) as executor:
@@ -38,7 +38,7 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
             end_offset = min((i + 1) * size_per_thread, disk_size)
 
             if start_offset < disk_size:
-                logging.debug(f"Submitting thread {i} with start_offset {start_offset} and end_offset {end_offset}")
+                #logging.debug(f"Submitting thread {i} with start_offset {start_offset} and end_offset {end_offset}")
                 try:
                     futures.append(
                         executor.submit(

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -1,11 +1,11 @@
 import config
 import fastcdc
 from concurrent.futures import ThreadPoolExecutor, as_completed
-
+import logging
 
 def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size):
     """
-    creates a threadpool to process the data in the disk
+    Creates a threadpool to process the data in the disk.
     """
     if sample_size != -1:
         disk_size = sample_size
@@ -22,17 +22,25 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar,
             if sample_size != -1 and config.bytes_total >= sample_size:
                 break
             handle = open(disk, "rb")
-            handle.seek(offset,0)
-            executor.submit(process_partial_disk, handle, iters, chunksize, hash_function, m, x, threads, pbar)
+            handle.seek(offset, 0)
+            
+            # Adjust size_per_thread for the last thread
+            if i == threads - 1:
+                size_per_thread = disk_size - offset
+            
+            logging.debug(f"Submitting thread {i} with offset {offset} and size {size_per_thread}")
+            executor.submit(process_partial_disk, handle, iters, chunksize, hash_function, m, x, threads, pbar, size_per_thread)
             offset += size_per_thread
             config.bytes_total += size_per_thread
-             
 
-def process_partial_disk(handle, iters, chunksize, hash_function, m, x, threads, pbar):
+def process_partial_disk(handle, iters, chunksize, hash_function, m, x, threads, pbar, size_per_thread):
     try:
-        chunker = fastcdc.fastcdc(handle, chunksize, chunksize, chunksize, hf = hash_function)
+        chunker = fastcdc.fastcdc(handle, chunksize, chunksize, chunksize, hf=hash_function)
     except Exception as e:
         clickl.echo(str(e))
+        with lock:
+            config.files_skipped += 1  # Increment skipped files count
+        logging.error(f"Error processing disk: {e}")
         return
 
     k = 256 * 64 // threads
@@ -42,14 +50,21 @@ def process_partial_disk(handle, iters, chunksize, hash_function, m, x, threads,
     i = 1
     for chunk in chunker:
         if int(chunk.hash, 16) % m == x:
-            # the chunk passes the filter. So add it to the fingerprints
-            config.fingerprints.add(int(chunk.hash, 16))
+            # Safely add the chunk hash to the fingerprints
+            with lock:
+                config.fingerprints.add(int(chunk.hash, 16))
         if iter_count == iters_by_k * i:
-            pbar.update(iters_by_k * chunksize)
+            with lock:
+                pbar.update(iters_by_k * chunksize)
             i += 1
         if iter_count >= iters:
             break
         iter_count += 1
+
+    # Safely update the total bytes processed
+    with lock:
+        config.bytes_total += iter_count * chunksize
+    logging.debug(f"Thread {threading.current_thread().name} processed {iter_count} chunks.")
 
 
 

--- a/Tools/DedupEstimationTool/file_scan.py
+++ b/Tools/DedupEstimationTool/file_scan.py
@@ -1,8 +1,15 @@
 import config
 import os
 import fastcdc
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
 
+# Create a lock for thread-safe access to shared resources
+lock = threading.Lock()
+
+# Configure logging
+logging.basicConfig(level=logging.DEBUG)
 
 def iter_files(path, recursive=False):
     if recursive:
@@ -15,7 +22,8 @@ def iter_files(path, recursive=False):
                 except GeneratorExit:
                     return
                 except:
-                    config.files_skipped += 1
+                    with lock:
+                        config.files_skipped += 1
     else:
         for name in os.listdir(path):
             filepath = os.path.join(path, name)
@@ -26,28 +34,33 @@ def iter_files(path, recursive=False):
                 except GeneratorExit:
                     return
                 except:
-                    config.files_skipped += 1
+                    with lock:
+                        config.files_skipped += 1
 
 
 def process_path(path, recursive, chunksize, hash_function, m, x, threads, pbar, sample_size):
     """
-    creates a threadpool to process the files in given path
+    Creates a threadpool to process the files in the given path.
     """
     def handler(fut):
-        pbar.update(1)
+        with lock:
+            pbar.update(1)
 
     if sample_size != -1:
         with ThreadPoolExecutor(max_workers=threads) as executor:
             for file in iter_files(path, recursive):
-                if config.bytes_total + file[1] > sample_size:
-                    continue
+                with lock:
+                    if config.bytes_total + file[1] > sample_size:
+                        continue
+                    config.bytes_total += file[1]
                 try:
                     f = open(file[0], 'r')
                     f.close()
                     executor.submit(process_file, file[0], file[1], chunksize, hash_function, m, x, sample_size).add_done_callback(handler)
-                    config.bytes_total += file[1]
-                except:
-                    config.files_skipped += 1
+                except Exception as e:
+                    with lock:
+                        config.files_skipped += 1
+                    logging.error(f"Error opening file {file[0]}: {e}")
     else:
         with ThreadPoolExecutor(max_workers=threads) as executor:
             for file in iter_files(path, recursive):
@@ -58,23 +71,30 @@ def process_file(file, filesize, chunksize, hash_function, m, x, sample_size):
     """
     Process the file and add the hash of unique chunks of the file into the global fingerprints.
     """
+    logging.debug(f"Thread {threading.current_thread().name} started processing file {file}.")
     try:
-        chunker = fastcdc.fastcdc(file, chunksize, chunksize, chunksize, hf = hash_function)
+        chunker = fastcdc.fastcdc(file, chunksize, chunksize, chunksize, hf=hash_function)
     except Exception as e:
-        config.files_skipped += 1
+        with lock:
+            config.files_skipped += 1
+        logging.error(f"Error processing file {file}: {e}")
         return
     
     for chunk in chunker:
         if int(chunk.hash, 16) % m == x:
-            # the chunk passes the filter. So add it to the fingerprints
-            config.fingerprints.add(int(chunk.hash, 16))
+            # The chunk passes the filter. So add it to the fingerprints
+            with lock:
+                config.fingerprints.add(int(chunk.hash, 16))
 
-    config.files_scanned += 1
-    if sample_size == -1:
-        config.bytes_total += filesize
+    with lock:
+        config.files_scanned += 1
+        if sample_size == -1:
+            config.bytes_total += filesize
 
-    config.chunk_count += filesize // chunksize
-    if filesize % chunksize != 0:
-        config.chunk_count += 1
-        
-    
+        config.chunk_count += filesize // chunksize
+        if filesize % chunksize != 0:
+            config.chunk_count += 1
+
+    logging.debug(f"Thread {threading.current_thread().name} finished processing file {file}.")
+
+

--- a/Tools/DedupEstimationTool/file_scan.py
+++ b/Tools/DedupEstimationTool/file_scan.py
@@ -56,7 +56,7 @@ def process_path(path, recursive, chunksize, hash_function, m, x, threads, pbar,
                 try:
                     f = open(file[0], 'r')
                     f.close()
-                    executor.submit(process_file, file[0], file[1], chunksize, hash_function, m, x, sample_size).add_done_callback(handler)
+                    executor.submit(process_file, file[0], file[1], chunksize, hash_function, m, x, sample_size, pbar).add_done_callback(handler)
                 except Exception as e:
                     with lock:
                         config.files_skipped += 1
@@ -64,10 +64,10 @@ def process_path(path, recursive, chunksize, hash_function, m, x, threads, pbar,
     else:
         with ThreadPoolExecutor(max_workers=threads) as executor:
             for file in iter_files(path, recursive):
-                executor.submit(process_file, file[0], file[1], chunksize, hash_function, m, x, sample_size).add_done_callback(handler)
+                executor.submit(process_file, file[0], file[1], chunksize, hash_function, m, x, sample_size, pbar).add_done_callback(handler)
 
 
-def process_file(file, filesize, chunksize, hash_function, m, x, sample_size):
+def process_file(file, filesize, chunksize, hash_function, m, x, sample_size, pbar):
     """
     Process the file and add the hash of unique chunks of the file into the global fingerprints.
     """
@@ -94,6 +94,8 @@ def process_file(file, filesize, chunksize, hash_function, m, x, sample_size):
         config.chunk_count += filesize // chunksize
         if filesize % chunksize != 0:
             config.chunk_count += 1
+
+        pbar.update(1)  # Update the progress bar for each file processed
 
     logging.debug(f"Thread {threading.current_thread().name} finished processing file {file}.")
 


### PR DESCRIPTION
# SSV-24707, SSV-24829

WHAT:
Fixed multithreading by adding locks
Added a new parameter to skip all-zero blocks
Revamped the implementation for RAW disks by breaking the disk into N parts based on the number of threads, and then using FastCDC to work on each part. Lastly, combining the results.

TESTING:
Manually tested with multiple configurations with and without --skip-zeroes. Alex has also tested on his setup.

