### PR TITLE
SSV-24978: Revert intermediate dedup_ratio (postfix) update

### DIFF
--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -194,8 +194,8 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
             #logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
 
             i = 0
-            bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
-            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
+            bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}{postfix}]'
+            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False, mininterval=0.5, miniters=1024*1024) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
                         #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -202,7 +202,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
 
             i = 0
             bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}{postfix}]'
-            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False, mininterval=0.5, miniters=1024*1024) as pbar:
+            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False, mininterval=0.5, miniters=1024*1024, postfix={"dedup_ratio": "N/A"}) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
                         #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -201,8 +201,8 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
             #logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
 
             i = 0
-            bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}{postfix}]'
-            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False, mininterval=0.5, miniters=1024*1024, postfix={"dedup_ratio": "N/A"}) as pbar:
+            bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
+            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False, mininterval=0.5, miniters=1024*1024) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
                         #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -122,9 +122,9 @@ def iter_files(path, recursive=False):
 )
 @click.option(
     "--read-block-size",
-    help="Size of the disk read block in MB (default: 4). Higher values may improve performance on fast disks. Only for raw disk scanning.",
+    help="Size of the disk read block in MB (default: 1). Higher values may improve performance on fast disks. Only for raw disk scanning.",
     type=click.IntRange(1, 256),
-    default=4,
+    default=1,
     show_default=True
 )
 def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_zeroes, nosampling, sample_size, isconfig, suppress_result, read_block_size):

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -120,7 +120,14 @@ def iter_files(path, recursive=False):
     is_flag=True,
     default=False
 )
-def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_zeroes, nosampling, sample_size, isconfig, suppress_result):
+@click.option(
+    "--read-block-size",
+    help="Size of the disk read block in MB (default: 4). Higher values may improve performance on fast disks. Only for raw disk scanning.",
+    type=click.IntRange(1, 256),
+    default=4,
+    show_default=True
+)
+def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_zeroes, nosampling, sample_size, isconfig, suppress_result, read_block_size):
     """
     Scan and report duplication.
     """
@@ -199,7 +206,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
                         #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
-                        executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size, skip_zeroes, lock)
+                        executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size, skip_zeroes, lock, read_block_size)
                         #logging.debug(f"Submitted disk scan for {path}")
                         i += 1
 

--- a/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
+++ b/Tools/DedupEstimationTool/DcsEstimateDedupRatio.py
@@ -22,41 +22,6 @@ from fastcdc.utils import DefaultHelp, supported_hashes
 # Create a lock for thread-safe access to shared resources
 lock = threading.Lock()
 
-import queue
-import time
-
-progress_queue = queue.Queue()
-stop_event = threading.Event()
-
-def progress_updater(pbar, progress_queue, stop_event, interval=1.0):
-
-    last_time = time.time()
-    pending = 0
-    latest_postfix = {}
-    last_postfix = {}
-
-    while not stop_event.is_set() or not progress_queue.empty():
-        try:
-            while True:
-                delta, postfix = progress_queue.get_nowait()
-                pending += delta
-                if postfix:
-                    latest_postfix.update(postfix)
-        except queue.Empty:
-            pass
-
-        now = time.time()
-        if now - last_time >= interval or stop_event.is_set():
-            if pending > 0:
-                pbar.update(pending)
-                if latest_postfix != last_postfix:
-                    pbar.set_postfix(latest_postfix, refresh=True)
-                    last_postfix = latest_postfix.copy()
-                pending = 0
-            last_time = now
-
-        time.sleep(0.1)
-
 def iter_files(path, recursive=False):
     if recursive:
         for root, subdirs, files in os.walk(path):
@@ -149,13 +114,7 @@ def iter_files(path, recursive=False):
     default=False,
     show_default=True
 )
-@click.option(
-    "--suppress-result",
-    help="Use this option to suppress final result on screen. Useful for running from a script. But this will not hide the progress bar.",
-    is_flag=True,
-    default=False
-)
-def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_zeroes, nosampling, sample_size, isconfig, suppress_result):
+def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_zeroes, nosampling, sample_size, isconfig):
     """
     Scan and report duplication.
     """
@@ -181,6 +140,7 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
         if sample_size != -1:
             sample_size = sample_size * 1024 * 1024 * 1024
 
+        supported = supported_hashes()
         hf = getattr(hashlib, hash_function)
 
         path_count = len(paths) # number of input path
@@ -228,18 +188,14 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
             #logging.debug(f"Starting disk scan now... calling ThreadPoolExecutor with max_workers={path_count}")
 
             i = 0
-            bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}{postfix}]'
-            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit="B", ascii=' #', bar_format=bar_format, leave=False) as pbar:
-                updater_thread = threading.Thread(target=progress_updater, args=(pbar, progress_queue, stop_event))
-                updater_thread.start()
-
+            bar_format = '{l_bar}{bar}| [time elapsed: {elapsed}, time remaining: {remaining}]'
+            with tqdm(total=bytes_total, desc="Estimating dedup ratio", unit=" path", ascii=' #', bar_format=bar_format, leave=False) as pbar:
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
-                        executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], progress_queue, sample_size, skip_zeroes, lock)
+                        #logging.debug(f"Submitting disk scan for {path} with size {sizes[i]}")
+                        executor.submit(process_disk, path, size, hf, m, x, max_threads, sizes[i], pbar, sample_size, skip_zeroes, lock)
+                        #logging.debug(f"Submitted disk scan for {path}")
                         i += 1
-
-                stop_event.set()
-                updater_thread.join()
 
             t.stop()
 
@@ -260,26 +216,26 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
                     results['paths'] = list(paths)
                     time_taken = int(Timer.timers.mean("scan")) + 0.1
                     data_per_s = bytes_total / time_taken
+                    click.echo("Unique Chunks:\t{}".format(intcomma(len(unique_chunks))))
                     results["unique_chunks"] = intcomma(len(unique_chunks))
+                    click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
                     results["unique_data"] = naturalsize(bytes_unique, True)
-                    results["non_zero_data_allocated"] = naturalsize(bytes_actual_total, True)
-                    results["space_scanned"] = naturalsize(bytes_total, True)
+                    click.echo("Zero Chunks Skipped:\t{}".format(intcomma(config.zero_chunks_skipped)))
+                    results["zero_chunks_skipped"] = naturalsize(config.zero_chunks_skipped)
+                    click.echo("Zero Data Skipped:\t{} bytes".format(config.zero_bytes_skipped))
+                    results["zero_data_skipped"] = naturalsize(config.zero_bytes_skipped, True)
+                    click.echo("Data scanned:\t{}".format(naturalsize(bytes_total, True)))
+                    results["data_scanned"] = naturalsize(bytes_total, True)
+                    click.echo("DeDupe Ratio:\t{:.2f}".format(bytes_actual_total / bytes_unique))
                     results["dedup_ratio"] = round(bytes_actual_total / bytes_unique, 2)
+                    click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
                     results["throughput"] = str(naturalsize(data_per_s, True)) + "/s"
+                    click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
                     
                     # Saving the output in a json file.
                     output = "DedupEstimationResult.txt"
                     with open(os.path.join(outpath,output), "w") as outfile:
                         outfile.write(json.dumps(results, indent = 2))
-
-                    if not suppress_result:
-                        click.echo("Unique Chunks:\t{}".format(intcomma(len(unique_chunks))))
-                        click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
-                        click.echo("Non-Zero Data Allocated:\t{}".format(naturalsize(bytes_actual_total, True)))
-                        click.echo("Space scanned:\t{}".format(naturalsize(bytes_total, True)))
-                        click.echo("DeDupe Ratio:\t{:.2f}".format(bytes_actual_total / bytes_unique))
-                        click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
-                        click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
                 else:
                     print("Too few unique chunks were detected. This could be due to: (1) high duplication, (2) insufficient sample size, (3) skipped zeroes, or (4) insufficient permissions.\nUse --nosampling option.\nOr skip --skip-zeroes option.\nOr try running the tool as administrator")
             else:
@@ -315,17 +271,12 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
             t = Timer("scan", logger=None)
             t.start()
 
-            bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [time elapsed: {elapsed}, time remaining: {remaining}{postfix}]'
+            bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [time elapsed: {elapsed}, time remaining: {remaining}]'
             with tqdm(total=files_to_scan, desc="Estimating dedup ratio", unit=" file", ascii=' #', bar_format=bar_format, leave=False) as pbar:
                 # seperately process files in each input path
-                updater_thread = threading.Thread(target=progress_updater, args=(pbar, progress_queue, stop_event))
-                updater_thread.start()
                 with ThreadPoolExecutor(max_workers=path_count) as executor:
                     for path in paths:
-                        executor.submit(process_path, path, recursive, size, hf, m, x, max_threads, progress_queue, sample_size)
-
-                stop_event.set()
-                updater_thread.join()
+                        executor.submit(process_path, path, recursive, size, hf, m, x, max_threads, pbar, sample_size)
 
             t.stop()
 
@@ -343,39 +294,33 @@ def scan(paths, recursive, size, hash_function, outpath, max_threads, raw, skip_
                     time_taken = int(Timer.timers.mean("scan")) + 0.1
                     data_per_s = bytes_total / time_taken
                     results["files"] = intcomma(file_count)
+                    click.echo("Unique Chunks:\t{}".format(intcomma(chunks_unique)))
                     results["unique_chunks"] = intcomma(chunks_unique)
+                    click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
                     results["unique_data"] = naturalsize(bytes_unique, True)
-                    results["non_zero_data_allocated"] = naturalsize(bytes_total, True)
-                    results["space_scanned"] = naturalsize(bytes_total, True)
+                    click.echo("Data scanned:\t{}".format(naturalsize(bytes_total, True)))
+                    results["data_scanned"] = naturalsize(bytes_total, True)
+                    click.echo("DeDupe Ratio:\t{:.2f}".format(dedup_ratio))
                     results["dedup_ratio"] = round(dedup_ratio, 2)
+                    click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
                     results["throughput"] = str(naturalsize(data_per_s, True)) + "/s"
+                    click.echo("Files Skipped:\t{}".format(intcomma(config.files_skipped)))
                     results["files_skippped"] = config.files_skipped
+                    click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
 
                     output = "DedupEstimationResult.txt"
                     with open(os.path.join(outpath, output), "w") as outfile:
                         outfile.write(json.dumps(results, indent=2))
-
-                    if not suppress_result:
-                        click.echo("Unique Chunks:\t{}".format(intcomma(chunks_unique)))
-                        click.echo("Unique Data:\t{}".format(naturalsize(bytes_unique, True)))
-                        click.echo("Non-Zero Data Allocated:\t{}".format(naturalsize(bytes_total, True)))
-                        click.echo("Space scanned:\t{}".format(naturalsize(bytes_total, True)))
-                        click.echo("DeDupe Ratio:\t{:.2f}".format(dedup_ratio))
-                        click.echo("Throughput:\t{}/s".format(naturalsize(data_per_s, True)))
-                        click.echo("Files Skipped:\t{}".format(intcomma(config.files_skipped)))
-                        click.echo("\nTime taken:\t{}".format(str(precisedelta(datetime.timedelta(seconds=time_taken)))))
                 else:
                     click.echo("Very less unique data / High Duplication.\nUse --nosampling option.\nOr try running the tool as administrator if admin privileges are required to read the files")
                 if sample_size != -1:
-                    click.echo("\nIf the file sizes exceed the sample size, the space scanned will be less than the sample size. To scan more data, increase the sample size")
+                    click.echo("\nIf the file sizes exceed the sample size, the data scanned will be less than the sample size. To scan more data, increase the sample size")
             else:
                 click.echo("No data or cannot access the files.\n")
         return 0
     except Exception as e:
         logging.error(f"An error occurred: {e}")
         return 2
-    finally:
-        pbar.close()
 
 
 if __name__ == "__main__":

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -89,6 +89,7 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
         buffer = bytearray()
         processed_bytes = 0
         total_size = end_offset - start_offset
+        last_postfix_update_mb = -1
 
         while processed_bytes < total_size:
             try:
@@ -142,6 +143,12 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
                                 else:
                                     config.bytes_total += c.length
                                     config.last_offsets_real[disk] = abs_offset + c.length
+                    if processed_bytes // (64 * 1024 * 1024) != last_postfix_update_mb:
+                        last_postfix_update_mb = processed_bytes // (64 * 1024 * 1024)
+                        with lock:
+                            pbar.set_postfix({
+                                "dedup_ratio": round(config.bytes_total / max(1, len(config.fingerprints) * m * chunksize), 2)
+                            })
                 except Exception as e:
                     logging.error(f"FastCDC failed on buffer: {e}")
                     logging.error(traceback.format_exc())
@@ -164,6 +171,12 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
                                 else:
                                     config.bytes_total += c.length
                                     config.last_offsets_real[disk] = abs_offset + c.length
+                    if processed_bytes // (64 * 1024 * 1024) != last_postfix_update_mb:
+                        last_postfix_update_mb = processed_bytes // (64 * 1024 * 1024)
+                        with lock:
+                            pbar.set_postfix({
+                                "dedup_ratio": round(config.bytes_total / max(1, len(config.fingerprints) * m * chunksize), 2)
+                            })
             except Exception as e:
                 logging.error(f"Final FastCDC failed: {e}")
                 logging.error(traceback.format_exc())
@@ -176,9 +189,6 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
                 f"Chunks: {config.chunk_count} | Unique: {len(config.fingerprints)} | "
                 f"Zero Skipped: {config.zero_chunks_skipped} ({naturalsize(config.zero_bytes_skipped)})"
             )'''
-            pbar.set_postfix( {
-                        "dedup_ratio": round(config.bytes_total / min(len(config.fingerprints) * m * chunksize, config.bytes_total), 2)
-                    }, refresh=True)
 
     except Exception as e:
         logging.error(f"Failed to process raw disk {disk}: {repr(e)}")
@@ -187,6 +197,10 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
             config.files_skipped += 1
 
     finally:
+        with lock:
+            pbar.set_postfix({
+                "dedup_ratio": round(config.bytes_total / max(1, len(config.fingerprints) * m * chunksize), 2)
+            })
         #logging.debug(f"Finished processing {disk} from {start_offset} to {end_offset}, now config.bytes_total={config.bytes_total}, config.chunk_count={config.chunk_count}, config.zero_chunks_skipped={config.zero_chunks_skipped}, config.zero_bytes_skipped={config.zero_bytes_skipped}")
         if handle is not None:
             os.close(handle)

--- a/Tools/DedupEstimationTool/disk_scan.py
+++ b/Tools/DedupEstimationTool/disk_scan.py
@@ -15,7 +15,7 @@ OVERLAP_SIZE = 2 * 1024 * 1024          # 2MB overlap for chunk boundary safety
 
 logging.basicConfig(level=logging.DEBUG)
 
-def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, progress_queue, sample_size, skip_zeroes, lock):
+def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, pbar, sample_size, skip_zeroes, lock):
     """
     Orchestrates the parallel processing of a disk by dividing it based on the number of threads
     and assigning each part to a thread for processing.
@@ -54,7 +54,7 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, progr
                             hash_function,
                             m,
                             x,
-                            progress_queue,
+                            pbar,
                             skip_zeroes,
                             lock
                         )
@@ -69,7 +69,7 @@ def process_disk(disk, chunksize, hash_function, m, x, threads, disk_size, progr
             except Exception as e:
                 logging.error(f"Error in thread execution: {e}")
 
-def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_function, m, x, progress_queue, skip_zeroes, lock):
+def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_function, m, x, pbar, skip_zeroes, lock):
     handle = None
     with lock:
         if disk not in config.last_offsets_real:
@@ -101,10 +101,7 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
                         config.zero_chunks_skipped += 1
                         config.zero_bytes_skipped += len(chunk)
                         config.last_offsets_zero[disk] = start_offset + processed_bytes + len(chunk)
-                    progress_queue.put((len(chunk), {
-                        "dedup_ratio": round(config.bytes_total / max(1, len(config.fingerprints) * m * chunksize), 2)
-                    }))
-
+                        pbar.update(len(chunk))
 
                     #logging.debug(f"[ZERO SKIP] Offset: {start_offset + processed_bytes}, Size: {len(chunk)}")
                     processed_bytes += len(chunk)
@@ -112,10 +109,8 @@ def process_partial_disk(disk, start_offset, end_offset, chunksize, hash_functio
                 else:
                     buffer.extend(chunk)
                     processed_bytes += len(chunk)
-                    progress_queue.put((len(chunk), {
-                        "dedup_ratio": round(config.bytes_total / max(1, len(config.fingerprints) * m * chunksize), 2)
-                    }))
-
+                    with lock:
+                        pbar.update(len(chunk))
                     #logging.debug(f"[READ] Offset: {start_offset + processed_bytes - len(chunk)}, Size: {len(chunk)}")
             except Exception as e:
                 logging.error(f"Error reading at offset {start_offset + processed_bytes}: {e}")

--- a/Tools/DedupEstimationTool/file_scan.py
+++ b/Tools/DedupEstimationTool/file_scan.py
@@ -81,10 +81,11 @@ def process_file(file, filesize, chunksize, hash_function, m, x, sample_size, pb
         return
     
     for chunk in chunker:
-        if int(chunk.hash, 16) % m == x:
+        h = int(chunk.hash, 16)
+        if h % m == x:
             # The chunk passes the filter. So add it to the fingerprints
             with lock:
-                config.fingerprints.add(int(chunk.hash, 16))
+                config.fingerprints.add(h)
 
     with lock:
         config.files_scanned += 1
@@ -94,8 +95,6 @@ def process_file(file, filesize, chunksize, hash_function, m, x, sample_size, pb
         config.chunk_count += filesize // chunksize
         if filesize % chunksize != 0:
             config.chunk_count += 1
-
-        pbar.update(1)  # Update the progress bar for each file processed
 
     logging.debug(f"Thread {threading.current_thread().name} finished processing file {file}.")
 

--- a/Tools/DedupEstimationTool/file_scan.py
+++ b/Tools/DedupEstimationTool/file_scan.py
@@ -71,7 +71,11 @@ def process_file(file, filesize, chunksize, hash_function, m, x, sample_size, pb
     """
     Process the file and add the hash of unique chunks of the file into the global fingerprints.
     """
-    logging.debug(f"Thread {threading.current_thread().name} started processing file {file}.")
+    if filesize == 0:
+        with lock:
+            config.files_skipped += 1
+        logging.warning(f"Skipping empty file {file}")
+        return
     try:
         chunker = fastcdc.fastcdc(file, chunksize, chunksize, chunksize, hf=hash_function)
     except Exception as e:
@@ -95,7 +99,5 @@ def process_file(file, filesize, chunksize, hash_function, m, x, sample_size, pb
         config.chunk_count += filesize // chunksize
         if filesize % chunksize != 0:
             config.chunk_count += 1
-
-    logging.debug(f"Thread {threading.current_thread().name} finished processing file {file}.")
 
 


### PR DESCRIPTION
# SSV-24978

### WHAT:
Reverted the changes done for showing intermediate dedup_ratio (postfix)
Also added a new parameter --read-block-size to improve the IO performance on high speed SSDs/RAID disks. Kept the default as 1MB for SSY based VDs.

### WHY:
To improve performance, Alex wants the postfix totally removed

### HOW:
To stop frequent screen updates, added miniters and mininterval
Removed all the postfix statements

### TEST:
